### PR TITLE
Optimize Python interpreter: ~4,500x speedup (trampoline + direct eval + JIT)

### DIFF
--- a/calysto_scheme/scheme.py
+++ b/calysto_scheme/scheme.py
@@ -665,6 +665,10 @@ def _eval_direct(exp, env):
                 exp = exp.cdr.cdr.car       # tail: loop with then-branch
             else:
                 exp = exp.cdr.cdr.cdr.car   # tail: loop with else-branch
+        elif tag is symbol_lambda_aexp:
+            return closure(exp.cdr.car, exp.cdr.cdr.car, env)
+        elif tag is symbol_begin_aexp:
+            return _eval_sequence_direct(exp.cdr, env)
         elif tag is symbol_app_aexp:
             op   = _eval_direct(exp.cdr.car, env)
             args = []

--- a/calysto_scheme/scheme.py
+++ b/calysto_scheme/scheme.py
@@ -41,6 +41,9 @@ sys.ps2 = "...: "
 
 PY3 = sys.version_info[0] == 3
 
+# Increase recursion limit for direct-eval fast path (deep Scheme recursion)
+sys.setrecursionlimit(max(10000, sys.getrecursionlimit()))
+
 __version__ = "1.4.9"
 
 #############################################################
@@ -569,10 +572,202 @@ def apply_handler2():
     handler_reg[1](*handler_reg[2:])
 
 def apply_proc():
+    if (isinstance(proc_reg, tuple) and len(proc_reg) == 6
+            and proc_reg[1] is b_proc_1_d and proc_reg[5]):
+        bodies, formals, cenv = proc_reg[2], proc_reg[3], proc_reg[4]
+        _args = args_reg
+        _k2   = k2_reg
+        _fail = fail_reg
+        try:
+            n = length(formals)
+            if n != length(_args):
+                raise _TrampolineFallback()
+            new_env = extend(cenv, formals, _args, make_empty_docstrings(n))
+            result = _eval_sequence_direct(bodies, new_env)
+            GLOBALS['value2_reg'] = _fail
+            GLOBALS['value1_reg'] = result
+            GLOBALS['k_reg'] = _k2
+            GLOBALS['pc'] = apply_cont2
+            return
+        except _TrampolineFallback:
+            GLOBALS['args_reg'] = _args   # restore for b_proc_1_d trampoline fallback
+            GLOBALS['k2_reg']   = _k2
+            GLOBALS['fail_reg'] = _fail
     proc_reg[1](*proc_reg[2:])
 
 def apply_macro():
     macro_reg[1](*macro_reg[2:])
+
+### Direct eval fast path for user closures:
+
+class _TrampolineFallback(Exception):
+    pass
+
+def _is_direct_eval_safe(bodies):
+    """True iff bodies contain no assign_aexp (set!) at any depth.
+    Stops recursion at inner lambda boundaries (they get their own analysis)."""
+    def _safe(exp):
+        if not isinstance(exp, cons):
+            return True
+        tag = exp.car
+        if tag is symbol_assign_aexp:
+            return False
+        # Inner lambdas are separate closures — don't recurse into them
+        if tag is symbol_lambda_aexp or tag is symbol_mu_lambda_aexp:
+            return True
+        cur = exp.cdr
+        while isinstance(cur, cons):
+            if not _safe(cur.car):
+                return False
+            cur = cur.cdr
+        return True
+    cur = bodies
+    while isinstance(cur, cons):
+        if not _safe(cur.car):
+            return False
+        cur = cur.cdr
+    return True
+
+def _extend_direct(env, formals, args_list):
+    """Extend environment from a Python list of arg values — no cons list construction."""
+    bindings = []
+    cache = {}
+    vars_cur = formals
+    for val in args_list:
+        b = cons(val, "")
+        bindings.append(b)
+        cache[vars_cur.car] = b
+        vars_cur = vars_cur.cdr
+    frame = cons(Vector(bindings), cons(formals, symbol_emptylist))
+    frame._search_cache = cache
+    return cons(symbol_environment, cons(frame, env.cdr))
+
+def _eval_direct(exp, env):
+    """Direct recursive AST interpreter. Raises _TrampolineFallback for unhandled cases."""
+    global _fast_prim_map
+    while True:
+        tag = exp.car
+        if tag is symbol_lit_aexp:
+            return exp.cdr.car
+        elif tag is symbol_lexical_address_aexp:
+            d   = exp.cdr.car
+            off = exp.cdr.cdr.car
+            return binding_value(
+                vector_ref(frame_bindings(list_ref(frames(env), d)), off))
+        elif tag is symbol_var_aexp:
+            b = search_env(env, exp.cdr.car)
+            if b is False:
+                raise _TrampolineFallback()
+            return binding_value(b)
+        elif tag is symbol_if_aexp:
+            test = _eval_direct(exp.cdr.car, env)
+            if test is not False:
+                exp = exp.cdr.cdr.car       # tail: loop with then-branch
+            else:
+                exp = exp.cdr.cdr.cdr.car   # tail: loop with else-branch
+        elif tag is symbol_app_aexp:
+            op   = _eval_direct(exp.cdr.car, env)
+            args = []
+            cur  = exp.cdr.cdr.car
+            while isinstance(cur, cons):
+                args.append(_eval_direct(cur.car, env))
+                cur = cur.cdr
+            # Inline _apply_direct for speed:
+            if isinstance(op, tuple) and op[0] is symbol_procedure:
+                fn = op[1]
+                if _fast_prim_map is None:
+                    _fast_prim_map = _build_fast_prim_map()
+                direct = _fast_prim_map.get(fn)
+                if direct is not None:
+                    return direct(args)
+                if len(op) == 6 and fn is b_proc_1_d and op[5]:
+                    new_env = _extend_direct(op[4], op[3], args)
+                    return _eval_sequence_direct(op[2], new_env)
+                raise _TrampolineFallback()
+            elif dlr_proc_q(op):
+                return dlr_apply(op, List(*args))
+            raise _TrampolineFallback()
+        else:
+            raise _TrampolineFallback()
+
+## Fast prim map: proc[1] function -> Python callable.
+## Built lazily on first use from the live toplevel environment.
+_fast_prim_map = None
+
+def _build_fast_prim_map():
+    """Populate the fast prim map by resolving known symbol names in toplevel_env."""
+    result = {}
+    name_to_direct = {
+        '+':     lambda args: plus(*args),
+        '-':     lambda args: minus(*args),
+        '*':     lambda args: multiply(*args),
+        '/':     lambda args: divide(*args),
+        '<':     lambda args: LessThan(*args),
+        '>':     lambda args: GreaterThan(*args),
+        '<=':    lambda args: LessThanEqual(*args),
+        '>=':    lambda args: GreaterThanEqual(*args),
+        '=':     lambda args: numeric_equal(*args),
+        'not':   lambda args: (args[0] is False),
+        'zero?': lambda args: (args[0] == 0),
+        'null?': lambda args: (args[0] is symbol_emptylist),
+        'pair?': lambda args: pair_q(args[0]),
+        'car':   lambda args: args[0].car,
+        'cdr':   lambda args: args[0].cdr,
+        'cons':  lambda args: cons(args[0], args[1]),
+    }
+    for sym_name, direct_fn in name_to_direct.items():
+        b = search_env(toplevel_env, make_symbol(sym_name))
+        if b is not False:
+            proc = binding_value(b)
+            if isinstance(proc, tuple) and proc[0] is symbol_procedure:
+                result[proc[1]] = direct_fn
+    return result
+
+def _apply_direct(proc, args, env):
+    global _fast_prim_map
+    if dlr_proc_q(proc):
+        return dlr_apply(proc, List(*args))
+    if isinstance(proc, tuple) and proc[0] is symbol_procedure:
+        fn = proc[1]
+        if _fast_prim_map is None:
+            _fast_prim_map = _build_fast_prim_map()
+        direct = _fast_prim_map.get(fn)
+        if direct is not None:
+            return direct(args)      # args is a Python list — no cons needed
+        if len(proc) == 6 and fn is b_proc_1_d and proc[5]:
+            bodies, formals, cenv = proc[2], proc[3], proc[4]
+            new_env = extend(cenv, formals, List(*args), make_empty_docstrings(len(args)))
+            return _eval_sequence_direct(bodies, new_env)
+    raise _TrampolineFallback()
+
+def _eval_sequence_direct(bodies, env):
+    cur = bodies
+    while True:
+        exp = cur.car
+        if cur.cdr is symbol_emptylist:
+            return _eval_direct(exp, env)   # tail expression: TCO via _eval_direct loop
+        _eval_direct(exp, env)              # intermediate expr: eval for side effects
+        cur = cur.cdr
+
+### Native b_proc_1_d and closure (direct-eval-aware):
+
+def b_proc_1_d(bodies, formals, env, _safe=False):
+    # _safe is used by apply_proc fast path, ignored here (trampoline path)
+    formals_and_args = process_formals_and_args(formals, args_reg, info_reg, handler_reg, fail_reg)
+    new_formals = (formals_and_args).car
+    new_args = (formals_and_args).cdr
+    if (numeric_equal(length(new_args), length(new_formals)) is not False):
+        GLOBALS['k_reg'] = k2_reg
+        GLOBALS['env_reg'] = extend(env, new_formals, new_args, make_empty_docstrings(length(new_args)))
+        GLOBALS['exps_reg'] = bodies
+        GLOBALS['pc'] = eval_sequence
+    else:
+        GLOBALS['msg_reg'] = "incorrect number of arguments in application"
+        GLOBALS['pc'] = runtime_error
+
+def closure(formals, bodies, env):
+    safe = _is_direct_eval_safe(bodies)
+    return make_proc(b_proc_1_d, bodies, formals, env, safe)
 
 ### Native frame functions (dict-cached for O(1) variable lookup):
 
@@ -3696,19 +3891,6 @@ def b_handler2_7_d(cexps, cvar, fexps, env, handler, k):
     GLOBALS['env_reg'] = new_env
     GLOBALS['exps_reg'] = cexps
     GLOBALS['pc'] = eval_sequence
-
-def b_proc_1_d(bodies, formals, env):
-    formals_and_args = process_formals_and_args(formals, args_reg, info_reg, handler_reg, fail_reg)
-    new_formals = (formals_and_args).car
-    new_args = (formals_and_args).cdr
-    if (numeric_equal(length(new_args), length(new_formals)) is not False):
-        GLOBALS['k_reg'] = k2_reg
-        GLOBALS['env_reg'] = extend(env, new_formals, new_args, make_empty_docstrings(length(new_args)))
-        GLOBALS['exps_reg'] = bodies
-        GLOBALS['pc'] = eval_sequence
-    else:
-        GLOBALS['msg_reg'] = "incorrect number of arguments in application"
-        GLOBALS['pc'] = runtime_error
 
 def b_proc_2_d(bodies, formals, runt, env):
     new_args = args_reg
@@ -8284,9 +8466,6 @@ def eval_choices():
 
 def association(var, value):
     return List(var, symbol_colon, value)
-
-def closure(formals, bodies, env):
-    return make_proc(b_proc_1_d, bodies, formals, env)
 
 def mu_closure(formals, runt, bodies, env):
     return make_proc(b_proc_2_d, bodies, formals, runt, env)

--- a/calysto_scheme/scheme.py
+++ b/calysto_scheme/scheme.py
@@ -697,23 +697,130 @@ _fast_prim_map = None
 def _build_fast_prim_map():
     """Populate the fast prim map by resolving known symbol names in toplevel_env."""
     result = {}
+
+    def _direct_map(args):
+        f, lst = args[0], args[1]
+        items = []
+        while isinstance(lst, cons):
+            items.append(_apply_direct(f, [lst.car]))
+            lst = lst.cdr
+        out = symbol_emptylist
+        for v in reversed(items):
+            out = cons(v, out)
+        return out
+
+    def _direct_for_each(args):
+        f, lst = args[0], args[1]
+        while isinstance(lst, cons):
+            _apply_direct(f, [lst.car])
+            lst = lst.cdr
+        return void_value
+
+    def _set_car(args):
+        args[0].car = args[1]
+        return void_value
+
+    def _set_cdr(args):
+        args[0].cdr = args[1]
+        return void_value
+
     name_to_direct = {
+        # Arithmetic
         '+':     lambda args: plus(*args),
         '-':     lambda args: minus(*args),
         '*':     lambda args: multiply(*args),
         '/':     lambda args: divide(*args),
+        # Numeric comparisons
         '<':     lambda args: LessThan(*args),
         '>':     lambda args: GreaterThan(*args),
         '<=':    lambda args: LessThanEqual(*args),
         '>=':    lambda args: GreaterThanEqual(*args),
         '=':     lambda args: numeric_equal(*args),
+        # Logic
         'not':   lambda args: (args[0] is False),
-        'zero?': lambda args: (args[0] == 0),
-        'null?': lambda args: (args[0] is symbol_emptylist),
-        'pair?': lambda args: pair_q(args[0]),
-        'car':   lambda args: args[0].car,
-        'cdr':   lambda args: args[0].cdr,
-        'cons':  lambda args: cons(args[0], args[1]),
+        # Numeric predicates / math
+        'zero?':     lambda args: (args[0] == 0),
+        'even?':     lambda args: even_q(args[0]),
+        'odd?':      lambda args: odd_q(args[0]),
+        'abs':       lambda args: abs(args[0]),
+        'min':       lambda args: min(*args),
+        'max':       lambda args: max(*args),
+        'modulo':    lambda args: modulo(args[0], args[1]),
+        'remainder': lambda args: remainder(args[0], args[1]),
+        'quotient':  lambda args: quotient(args[0], args[1]),
+        'expt':      lambda args: expt_native(args[0], args[1]),
+        'sqrt':      lambda args: sqrt(args[0]),
+        'round':     lambda args: round(args[0]),
+        # Type predicates
+        'null?':      lambda args: (args[0] is symbol_emptylist),
+        'pair?':      lambda args: pair_q(args[0]),
+        'number?':    lambda args: number_q(args[0]),
+        'string?':    lambda args: string_q(args[0]),
+        'symbol?':    lambda args: symbol_q(args[0]),
+        'char?':      lambda args: char_q(args[0]),
+        'boolean?':   lambda args: boolean_q(args[0]),
+        'vector?':    lambda args: vector_q(args[0]),
+        'list?':      lambda args: list_q(args[0]),
+        'procedure?': lambda args: procedure_q(args[0]),
+        # Equality
+        'eq?':    lambda args: eq_q(args[0], args[1]),
+        'eqv?':   lambda args: eqv_q(args[0], args[1]),
+        'equal?': lambda args: equal_q(args[0], args[1]),
+        # Pair / list construction and access
+        'car':    lambda args: args[0].car,
+        'cdr':    lambda args: args[0].cdr,
+        'cons':   lambda args: cons(args[0], args[1]),
+        'set-car!': _set_car,
+        'set-cdr!': _set_cdr,
+        'caar':   lambda args: args[0].car.car,
+        'cadr':   lambda args: args[0].cdr.car,
+        'cdar':   lambda args: args[0].car.cdr,
+        'cddr':   lambda args: args[0].cdr.cdr,
+        'cadar':  lambda args: args[0].car.cdr.car,
+        'caddr':  lambda args: args[0].cdr.cdr.car,
+        'cdddr':  lambda args: args[0].cdr.cdr.cdr,
+        'cadddr': lambda args: args[0].cdr.cdr.cdr.car,
+        # List operations
+        'list':      lambda args: List(*args),
+        'length':    lambda args: length(args[0]),
+        'reverse':   lambda args: reverse(args[0]),
+        'append':    lambda args: append(*args),
+        'list-ref':  lambda args: list_ref(args[0], args[1]),
+        # Search
+        'memq':   lambda args: memq(args[0], args[1]),
+        'memv':   lambda args: memv(args[0], args[1]),
+        'member': lambda args: member(args[0], args[1]),
+        'assq':   lambda args: assq(args[0], args[1]),
+        'assv':   lambda args: assv(args[0], args[1]),
+        # Vector operations
+        'make-vector':   lambda args: make_vector(args[0]),
+        'vector-ref':    lambda args: vector_ref(args[0], args[1]),
+        'vector-set!':   lambda args: (vector_set_b(args[0], args[1], args[2]), void_value)[1],
+        'vector-length': lambda args: vector_length(args[0]),
+        'vector->list':  lambda args: vector_to_list(args[0]),
+        'list->vector':  lambda args: list_to_vector(args[0]),
+        # String operations
+        'string-length':  lambda args: string_length(args[0]),
+        'string-ref':     lambda args: string_ref(args[0], args[1]),
+        'string-append':  lambda args: string_append(*args),
+        'substring':      lambda args: substring(args[0], args[1], args[2]),
+        'string->list':   lambda args: string_to_list(args[0]),
+        'list->string':   lambda args: list_to_string(args[0]),
+        'string->number': lambda args: string_to_number(args[0]),
+        'number->string': lambda args: number_to_string(args[0]),
+        'string=?':       lambda args: string_is__q(args[0], args[1]),
+        'string<?':       lambda args: stringLessThan_q(args[0], args[1]),
+        # Symbol / char operations
+        'symbol->string':  lambda args: symbol_to_string(args[0]),
+        'string->symbol':  lambda args: string_to_symbol(args[0]),
+        'char->integer':   lambda args: char_to_integer(args[0]),
+        'integer->char':   lambda args: integer_to_char(args[0]),
+        'char-alphabetic?': lambda args: char_alphabetic_q(args[0]),
+        'char-numeric?':    lambda args: char_numeric_q(args[0]),
+        'char-whitespace?': lambda args: char_whitespace_q(args[0]),
+        # Higher-order (propagate _TrampolineFallback if proc not directly evaluable)
+        'map':      _direct_map,
+        'for-each': _direct_for_each,
     }
     for sym_name, direct_fn in name_to_direct.items():
         b = search_env(toplevel_env, make_symbol(sym_name))

--- a/calysto_scheme/scheme.py
+++ b/calysto_scheme/scheme.py
@@ -519,31 +519,120 @@ def vector_length(vec):
 ### Native make- functions:
 
 def make_proc(*args):
-    return List(symbol_procedure, *args)
+    return (symbol_procedure,) + args
 
 def make_macro(*args):
-    return List(symbol_macro_transformer, *args)
+    return (symbol_macro_transformer,) + args
 
 def make_cont(*args):
-    return List(symbol_continuation, *args)
+    return (symbol_continuation,) + args
 
 def make_cont2(*args):
-    return List(symbol_continuation2, *args)
+    return (symbol_continuation2,) + args
 
 def make_cont3(*args):
-    return List(symbol_continuation3, *args)
+    return (symbol_continuation3,) + args
 
 def make_cont4(*args):
-    return List(symbol_continuation4, *args)
+    return (symbol_continuation4,) + args
 
 def make_fail(*args):
-    return List(symbol_fail_continuation, *args)
+    return (symbol_fail_continuation,) + args
 
 def make_handler(*args):
-    return List(symbol_handler, *args)
+    return (symbol_handler,) + args
 
 def make_handler2(*args):
-    return List(symbol_handler2, *args)
+    return (symbol_handler2,) + args
+
+### Native apply dispatch functions (tuple-based):
+
+def apply_cont():
+    k_reg[1](*k_reg[2:])
+
+def apply_cont2():
+    k_reg[1](*k_reg[2:])
+
+def apply_cont3():
+    k_reg[1](*k_reg[2:])
+
+def apply_cont4():
+    k_reg[1](*k_reg[2:])
+
+def apply_fail():
+    fail_reg[1](*fail_reg[2:])
+
+def apply_handler():
+    handler_reg[1](*handler_reg[2:])
+
+def apply_handler2():
+    handler_reg[1](*handler_reg[2:])
+
+def apply_proc():
+    proc_reg[1](*proc_reg[2:])
+
+def apply_macro():
+    macro_reg[1](*macro_reg[2:])
+
+### Native frame functions (dict-cached for O(1) variable lookup):
+
+def make_frame(variables, values, docstrings):
+    # Single pass: build bindings list and search cache simultaneously
+    bindings = []
+    cache = {}
+    vars_cur, vals_cur, docs_cur = variables, values, docstrings
+    while isinstance(vars_cur, cons):
+        b = cons(vals_cur.car, docs_cur.car)  # make_binding inlined
+        bindings.append(b)
+        cache[vars_cur.car] = b
+        vars_cur = vars_cur.cdr
+        vals_cur = vals_cur.cdr
+        docs_cur = docs_cur.cdr
+    bindings_vector = Vector(bindings)
+    frame = List(bindings_vector, variables)
+    frame._search_cache = cache
+    return frame
+
+def add_binding(new_var, new_binding, frame):
+    vars = (frame).cdr.car
+    old_bindings = (frame).car  # Vector
+    new_bindings = Vector(list(old_bindings) + [new_binding])
+    new_frame = List(new_bindings, append(vars, List(new_var)))
+    cache = getattr(frame, '_search_cache', None)
+    if cache is not None:
+        new_cache = dict(cache)
+        new_cache[new_var] = new_binding
+        new_frame._search_cache = new_cache
+    return new_frame
+
+def continuation_object_q(x):
+    return (isinstance(x, tuple) and len(x) > 0 and
+            x[0] in (symbol_continuation, symbol_continuation2,
+                     symbol_continuation3, symbol_continuation4))
+
+_empty_docstrings_cache = {}
+def make_empty_docstrings(n):
+    if n not in _empty_docstrings_cache:
+        result = symbol_emptylist
+        for _ in range(n):
+            result = cons("", result)
+        _empty_docstrings_cache[n] = result
+    return _empty_docstrings_cache[n]
+
+def process_args(args, params, info, handler, fail):
+    return args
+
+def process_formals(params, info, handler, fail):
+    # Fast path: if all params are plain Symbols, return unchanged (avoids Map allocation)
+    cur = params
+    while isinstance(cur, cons):
+        if not isinstance(cur.car, Symbol):
+            return Map(get_symbol, params)
+        cur = cur.cdr
+    return params
+
+def process_formals_and_args(params, args, info, handler, fail):
+    return cons(process_formals(params, info, handler, fail), args)
 
 ### Native other functions:
 
@@ -639,7 +728,7 @@ def list_q(item):
     return current is symbol_emptylist
 
 def procedure_q(item):
-    return pair_q(item) and (item.car is symbol_procedure)
+    return isinstance(item, tuple) and len(item) > 0 and item[0] is symbol_procedure
 
 def symbol_q(item):
     return ((isinstance(item, Symbol) or association_q(item))
@@ -1034,6 +1123,9 @@ def make_safe(item):
 
 def search_frame(frame, variable):
     if isinstance(frame, cons):
+        cache = getattr(frame, '_search_cache', None)
+        if cache is not None:
+            return cache.get(variable, False)
         bindings = frame.car
         variables = frame.cdr.car
         i = 0
@@ -1913,9 +2005,6 @@ temp_2 = symbol_undefined
 temp_3 = symbol_undefined
 temp_4 = symbol_undefined
 temp_1 = symbol_undefined
-def apply_cont():
-    Apply((k_reg).cdr.car, (k_reg).cdr.cdr)
-
 def b_cont_1_d(chars, fail, k):
     GLOBALS['value3_reg'] = fail
     GLOBALS['value2_reg'] = chars
@@ -2022,7 +2111,7 @@ def b_cont_16_d(aclauses, name, info, fail, k):
     GLOBALS['pc'] = apply_cont2
 
 def b_cont_17_d(adatum, senv, info, handler, fail, k):
-    if (False if ((original_source_info_q(adatum)) is False) else True):
+    if (original_source_info_q(adatum) is not False):
         GLOBALS['k_reg'] = k
         GLOBALS['fail_reg'] = fail
         GLOBALS['handler_reg'] = handler
@@ -2078,7 +2167,7 @@ def b_cont_24_d(bodies2, name, formals, k):
     GLOBALS['pc'] = apply_cont
 
 def b_cont_25_d(adatum, bodies, handler, fail, k):
-    if (False if ((value_reg) is False) else True):
+    if (value_reg is not False):
         GLOBALS['fail_reg'] = fail
         GLOBALS['handler_reg'] = handler
         GLOBALS['adatum_reg'] = adatum
@@ -2100,12 +2189,12 @@ def b_cont_27_d(bindings, k):
 
 def b_cont_28_d(clauses, var, k):
     clause = car_hat(clauses)
-    if (False if ((eq_q_hat(car_hat(clause), symbol_else)) is False) else True):
+    if (eq_q_hat(car_hat(clause), symbol_else) is not False):
         GLOBALS['value_reg'] = cons(clause, value_reg)
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
     else:
-        if (False if ((symbol_q_hat(car_hat(clause))) is False) else True):
+        if (symbol_q_hat(car_hat(clause)) is not False):
             GLOBALS['value_reg'] = cons(append(List(append(List(symbol_eq_q), append(List(var), List(append(List(symbol_quote), List(car_hat(clause))))))), at_hat(cdr_hat(clause))), value_reg)
             GLOBALS['k_reg'] = k
             GLOBALS['pc'] = apply_cont
@@ -2127,14 +2216,14 @@ def b_cont_30_d(cdrs, fields, name, k):
     GLOBALS['pc'] = apply_cont
 
 def b_cont_31_d(adatum, macro_keyword, fail, k):
-    if (False if ((has_source_info_q(value_reg)) is False) else True):
+    if (has_source_info_q(value_reg) is not False):
         GLOBALS['value2_reg'] = fail
         GLOBALS['value1_reg'] = value_reg
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont2
     else:
         info = get_source_info(adatum)
-        if (False if ((original_source_info_q(adatum)) is False) else True):
+        if (original_source_info_q(adatum) is not False):
             GLOBALS['value2_reg'] = fail
             GLOBALS['value1_reg'] = replace_info(value_reg, snoc(macro_keyword, info))
             GLOBALS['k_reg'] = k
@@ -2152,7 +2241,7 @@ def b_cont_32_d(adatum, macro_keyword, fail, k):
     GLOBALS['pc'] = annotate_cps
 
 def b_cont_33_d(aclauses, adatum, clauses, right_apattern, right_pattern, handler, fail, k):
-    if (False if ((value_reg) is False) else True):
+    if (value_reg is not False):
         GLOBALS['k2_reg'] = make_cont2(b_cont2_56_d, fail, k)
         GLOBALS['ap_reg'] = right_apattern
         GLOBALS['s_reg'] = value_reg
@@ -2274,7 +2363,7 @@ def b_cont_50_d(fail, k2):
     GLOBALS['pc'] = apply_cont2
 
 def b_cont_51_d(x, y, k):
-    if (False if ((value_reg) is False) else True):
+    if (value_reg is not False):
         GLOBALS['k_reg'] = k
         GLOBALS['y_reg'] = (y).cdr
         GLOBALS['x_reg'] = (x).cdr
@@ -2285,7 +2374,7 @@ def b_cont_51_d(x, y, k):
         GLOBALS['pc'] = apply_cont
 
 def b_cont_52_d(i, v1, v2, k):
-    if (False if ((value_reg) is False) else True):
+    if (value_reg is not False):
         GLOBALS['k_reg'] = k
         GLOBALS['i_reg'] = (i) - (1)
         GLOBALS['v2_reg'] = v2
@@ -2297,7 +2386,7 @@ def b_cont_52_d(i, v1, v2, k):
         GLOBALS['pc'] = apply_cont
 
 def b_cont_53_d(ls, x, y, info, handler, fail, k):
-    if (False if ((value_reg) is False) else True):
+    if (value_reg is not False):
         GLOBALS['value2_reg'] = fail
         GLOBALS['value1_reg'] = y
         GLOBALS['k_reg'] = k
@@ -2313,7 +2402,7 @@ def b_cont_53_d(ls, x, y, info, handler, fail, k):
         GLOBALS['pc'] = member_loop
 
 def b_cont_54_d(pattern, var, k):
-    if (False if ((value_reg) is False) else True):
+    if (value_reg is not False):
         GLOBALS['value_reg'] = True
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
@@ -2324,7 +2413,7 @@ def b_cont_54_d(pattern, var, k):
         GLOBALS['pc'] = occurs_q
 
 def b_cont_55_d(ap2, p1, p2, k):
-    if (False if ((value_reg) is False) else True):
+    if (value_reg is not False):
         GLOBALS['value_reg'] = False
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
@@ -2334,7 +2423,7 @@ def b_cont_55_d(ap2, p1, p2, k):
         GLOBALS['pc'] = apply_cont
 
 def b_cont_56_d(s_car, k):
-    if (False if ((not(value_reg)) is False) else True):
+    if (not(value_reg) is not False):
         GLOBALS['value_reg'] = False
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
@@ -2344,7 +2433,7 @@ def b_cont_56_d(s_car, k):
         GLOBALS['pc'] = apply_cont
 
 def b_cont_57_d(apair1, apair2, pair1, pair2, k):
-    if (False if ((not(value_reg)) is False) else True):
+    if (not(value_reg) is not False):
         GLOBALS['value_reg'] = False
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
@@ -2354,9 +2443,6 @@ def b_cont_57_d(apair1, apair2, pair1, pair2, k):
         GLOBALS['s_reg'] = value_reg
         GLOBALS['pattern_reg'] = (pair1).cdr
         GLOBALS['pc'] = instantiate_hat
-
-def apply_cont2():
-    Apply((k_reg).cdr.car, (k_reg).cdr.cdr)
 
 def b_cont2_1_d(token, k):
     GLOBALS['value1_reg'] = cons(token, value1_reg)
@@ -2401,7 +2487,7 @@ def b_cont2_8_d(info, k):
     GLOBALS['pc'] = apply_cont2
 
 def b_cont2_9_d(name, formals, info, k):
-    if (False if (((list_q(formals)) and (not(association_q(formals)))) is False) else True):
+    if ((list_q(formals)) and (not(association_q(formals))) is not False):
         GLOBALS['value1_reg'] = trace_lambda_aexp(name, formals, value1_reg, info)
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont2
@@ -2465,7 +2551,7 @@ def b_cont2_17_d(info, k):
     GLOBALS['pc'] = apply_cont2
 
 def b_cont2_18_d(formals, info, k):
-    if (False if (((list_q(formals)) and (not(association_q(formals)))) is False) else True):
+    if ((list_q(formals)) and (not(association_q(formals))) is not False):
         GLOBALS['value1_reg'] = lambda_aexp(formals, value1_reg, info)
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont2
@@ -2611,7 +2697,7 @@ def b_cont2_41_d(senv, src, tokens_left, handler, k):
     GLOBALS['pc'] = aparse_sexps
 
 def b_cont2_42_d(formals, handler, fail, k):
-    if (False if ((((value1_reg) is symbol_emptylist)) is False) else True):
+    if (((value1_reg) is symbol_emptylist) is not False):
         GLOBALS['value_reg'] = append(List(symbol_lambda_no_defines), append(List(formals), at_hat(value2_reg)))
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
@@ -2619,7 +2705,7 @@ def b_cont2_42_d(formals, handler, fail, k):
         return create_letrec_bindings_hat(value1_reg, handler, fail, make_cont(b_cont_23_d, value2_reg, formals, k))
 
 def b_cont2_43_d(name, formals, handler, fail, k):
-    if (False if ((((value1_reg) is symbol_emptylist)) is False) else True):
+    if (((value1_reg) is symbol_emptylist) is not False):
         GLOBALS['value_reg'] = append(List(symbol_trace_lambda_no_defines), append(List(name), append(List(formals), at_hat(value2_reg))))
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
@@ -2654,13 +2740,13 @@ def b_cont2_48_d(exp, k):
 
 def b_cont2_49_d(clauses, var, k2):
     clause = car_hat(clauses)
-    if (False if ((eq_q_hat(car_hat(clause), symbol_else)) is False) else True):
+    if (eq_q_hat(car_hat(clause), symbol_else) is not False):
         GLOBALS['value2_reg'] = cons(List(symbol_else, List(symbol_else_code)), value2_reg)
         GLOBALS['value1_reg'] = cons(append(List(symbol_else_code), List(append(List(symbol_lambda), append(List(symbol_emptylist), at_hat(cdr_hat(clause)))))), value1_reg)
         GLOBALS['k_reg'] = k2
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((symbol_q_hat(car_hat(clause))) is False) else True):
+        if (symbol_q_hat(car_hat(clause)) is not False):
             name = car_hat(clause)
             GLOBALS['value2_reg'] = cons(append(List(append(List(symbol_eq_q), append(List(var), List(append(List(symbol_quote), List(car_hat(clause))))))), List(append(List(symbol_Apply), append(List(name), List(append(List(symbol_quote), List(symbol_emptylist))))))), value2_reg)
             GLOBALS['value1_reg'] = cons(append(List(name), List(append(List(symbol_lambda), append(List(symbol_emptylist), at_hat(cdr_hat(clause)))))), value1_reg)
@@ -2675,13 +2761,13 @@ def b_cont2_49_d(clauses, var, k2):
 
 def b_cont2_50_d(clauses, var, k2):
     clause = car_hat(clauses)
-    if (False if ((eq_q_hat(car_hat(clause), symbol_else)) is False) else True):
+    if (eq_q_hat(car_hat(clause), symbol_else) is not False):
         GLOBALS['value2_reg'] = cons(append(List(symbol_else), List(List(symbol_else_code))), value2_reg)
         GLOBALS['value1_reg'] = cons(append(List(symbol_else_code), List(append(List(symbol_lambda), append(List(symbol_emptylist), at_hat(cdr_hat(clause)))))), value1_reg)
         GLOBALS['k_reg'] = k2
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((symbol_q_hat(car_hat(clause))) is False) else True):
+        if (symbol_q_hat(car_hat(clause)) is not False):
             name = car_hat(clause)
             GLOBALS['value2_reg'] = cons(append(List(append(List(symbol_eq_q), append(List(append(List(symbol_car), List(var))), List(append(List(symbol_quote), List(car_hat(clause))))))), List(append(List(symbol_Apply), append(List(name), List(append(List(symbol_cdr), List(var))))))), value2_reg)
             GLOBALS['value1_reg'] = cons(append(List(name), List(append(List(symbol_lambda), append(List(cadr_hat(clause)), at_hat(cddr_hat(clause)))))), value1_reg)
@@ -2764,18 +2850,18 @@ def b_cont2_62_d(exp, k):
     GLOBALS['pc'] = apply_cont2
 
 def b_cont2_63_d(args, exp, env, info, handler, k):
-    if (False if ((_staruse_stack_trace_star) is False) else True):
+    if (_staruse_stack_trace_star is not False):
         push_stack_trace_b(exp)
-    if (False if ((dlr_proc_q(value1_reg)) is False) else True):
+    if (dlr_proc_q(value1_reg) is not False):
         result = dlr_apply(value1_reg, args)
-        if (False if ((_staruse_stack_trace_star) is False) else True):
+        if (_staruse_stack_trace_star is not False):
             pop_stack_trace_b(exp)
         GLOBALS['value1_reg'] = result
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((procedure_object_q(value1_reg)) is False) else True):
-            if (False if ((_staruse_stack_trace_star) is False) else True):
+        if (procedure_object_q(value1_reg) is not False):
+            if (_staruse_stack_trace_star is not False):
                 GLOBALS['k2_reg'] = make_cont2(b_cont2_62_d, exp, k)
                 GLOBALS['fail_reg'] = value2_reg
                 GLOBALS['handler_reg'] = handler
@@ -2825,19 +2911,19 @@ def b_cont2_67_d(info, handler):
     col = get_start_char(info)
     line = get_start_line(info)
     src = get_srcfile(info)
-    if (False if ((exception_object_q(value1_reg)) is False) else True):
+    if (exception_object_q(value1_reg) is not False):
         GLOBALS['fail_reg'] = value2_reg
         GLOBALS['exception_reg'] = value1_reg
         GLOBALS['handler_reg'] = handler
         GLOBALS['pc'] = apply_handler2
     else:
-        if (False if ((string_q(value1_reg)) is False) else True):
+        if (string_q(value1_reg) is not False):
             GLOBALS['fail_reg'] = value2_reg
             GLOBALS['exception_reg'] = make_exception("Exception", value1_reg, src, line, col)
             GLOBALS['handler_reg'] = handler
             GLOBALS['pc'] = apply_handler2
         else:
-            if (False if (((list_q(value1_reg)) and (valid_exception_type_q((value1_reg).car)) and (string_q((value1_reg).cdr.car))) is False) else True):
+            if ((list_q(value1_reg)) and (valid_exception_type_q((value1_reg).car)) and (string_q((value1_reg).cdr.car)) is not False):
                 GLOBALS['fail_reg'] = value2_reg
                 GLOBALS['exception_reg'] = make_exception((value1_reg).car, (value1_reg).cdr.car, src, line, col)
                 GLOBALS['handler_reg'] = handler
@@ -2870,7 +2956,7 @@ def b_cont2_70_d(name, env, info, handler, k):
     GLOBALS['pc'] = lookup_binding_in_first_frame
 
 def b_cont2_71_d(docstring, var, k):
-    if (False if ((procedure_object_q(value1_reg)) is False) else True):
+    if (procedure_object_q(value1_reg) is not False):
         set_global_value_b(var, dlr_func(value1_reg))
     else:
         set_global_value_b(var, value1_reg)
@@ -2950,7 +3036,7 @@ def b_cont2_81_d(k):
     GLOBALS['pc'] = apply_cont2
 
 def b_cont2_82_d(else_exp, then_exp, env, handler, k):
-    if (False if ((value1_reg) is False) else True):
+    if (value1_reg is not False):
         GLOBALS['k_reg'] = k
         GLOBALS['fail_reg'] = value2_reg
         GLOBALS['handler_reg'] = handler
@@ -3009,7 +3095,7 @@ def b_cont2_87_d(assertions, nums, test_name, handler, k):
     GLOBALS['pc'] = filter_assertions
 
 def b_cont2_88_d(assertions, msg, proc_exp, result_val, right, test_exp, test_name, traceback, verbose, wrong, env, handler, k):
-    if (False if ((verbose) is False) else True):
+    if (verbose is not False):
         printf("~a\n", traceback)
         printf("  Procedure    : ~a\n", proc_exp)
         printf("       src     : ~a\n", test_exp)
@@ -3114,7 +3200,7 @@ def b_cont2_99_d(handler, k2):
     GLOBALS['pc'] = read_sexp
 
 def b_cont2_100_d(k):
-    if (False if ((((load_stack) is symbol_emptylist)) is False) else True):
+    if (((load_stack) is symbol_emptylist) is not False):
         printf("WARNING: empty load-stack encountered!\n")
     else:
         GLOBALS['load_stack'] = (load_stack).cdr
@@ -3132,7 +3218,7 @@ def b_cont2_101_d(filename, env2, handler, k):
     GLOBALS['pc'] = read_and_eval_asexps
 
 def b_cont2_102_d(src, tokens_left, env2, handler, k):
-    if (False if ((token_type_q(first(tokens_left), symbol_end_marker)) is False) else True):
+    if (token_type_q(first(tokens_left), symbol_end_marker) is not False):
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont2
     else:
@@ -3162,12 +3248,12 @@ def b_cont2_104_d(filenames, env2, info, handler, k):
     GLOBALS['pc'] = load_files
 
 def b_cont2_105_d(args, info, handler, k2):
-    if (False if (((value1_reg) is (True)) is False) else True):
+    if ((value1_reg) is (True) is not False):
         GLOBALS['value1_reg'] = symbol_ok
         GLOBALS['k_reg'] = k2
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((numeric_equal(length(args), 3)) is False) else True):
+        if (numeric_equal(length(args), 3) is not False):
             GLOBALS['fail_reg'] = value2_reg
             GLOBALS['handler_reg'] = handler
             GLOBALS['info_reg'] = info
@@ -3181,7 +3267,7 @@ def b_cont2_105_d(args, info, handler, k2):
             GLOBALS['pc'] = assertion_error
 
 def b_cont2_106_d(lst, k2):
-    if (False if ((member((lst).car, value1_reg)) is False) else True):
+    if (member((lst).car, value1_reg) is not False):
         GLOBALS['k_reg'] = k2
         GLOBALS['pc'] = apply_cont2
     else:
@@ -3312,7 +3398,7 @@ def b_cont2_122_d(elements, k2):
     GLOBALS['pc'] = apply_cont2
 
 def b_cont2_123_d(elements, proc, x, env2, info, handler, k2):
-    if (False if ((value1_reg) is False) else True):
+    if (value1_reg is not False):
         GLOBALS['value1_reg'] = cons(x, elements)
         GLOBALS['k_reg'] = k2
         GLOBALS['pc'] = apply_cont2
@@ -3362,11 +3448,8 @@ def b_cont2_128_d(s2, k2):
     GLOBALS['pattern_reg'] = value1_reg
     GLOBALS['pc'] = instantiate_hat
 
-def apply_cont3():
-    Apply((k_reg).cdr.car, (k_reg).cdr.cdr)
-
 def b_cont3_1_d(src, handler, k):
-    if (False if ((token_type_q(value1_reg, symbol_end_marker)) is False) else True):
+    if (token_type_q(value1_reg, symbol_end_marker) is not False):
         GLOBALS['value2_reg'] = value3_reg
         GLOBALS['value1_reg'] = List(value1_reg)
         GLOBALS['k_reg'] = k
@@ -3403,9 +3486,6 @@ def b_cont3_5_d(k):
     GLOBALS['value2_reg'] = value3_reg
     GLOBALS['k_reg'] = k
     GLOBALS['pc'] = apply_cont2
-
-def apply_cont4():
-    Apply((k_reg).cdr.car, (k_reg).cdr.cdr)
 
 def b_cont4_1_d(src, start, k):
     GLOBALS['k_reg'] = make_cont(b_cont_8_d, value2_reg, value3_reg, value4_reg, k)
@@ -3449,7 +3529,7 @@ def b_cont4_6_d(expected_terminator, sexp1, src, handler, k):
     GLOBALS['pc'] = close_sexp_sequence
 
 def b_cont4_7_d(expected_terminator, src, handler, k):
-    if (False if ((token_type_q(first(value3_reg), symbol_dot)) is False) else True):
+    if (token_type_q(first(value3_reg), symbol_dot) is not False):
         GLOBALS['k_reg'] = make_cont4(b_cont4_6_d, expected_terminator, value1_reg, src, handler, k)
         GLOBALS['fail_reg'] = value4_reg
         GLOBALS['handler_reg'] = handler
@@ -3487,7 +3567,7 @@ def b_cont4_10_d():
     GLOBALS['pc'] = aparse
 
 def b_cont4_11_d(handler, k2):
-    if (False if ((token_type_q(first(value3_reg), symbol_end_marker)) is False) else True):
+    if (token_type_q(first(value3_reg), symbol_end_marker) is not False):
         GLOBALS['k_reg'] = k2
         GLOBALS['fail_reg'] = value4_reg
         GLOBALS['handler_reg'] = handler
@@ -3503,7 +3583,7 @@ def b_cont4_11_d(handler, k2):
         GLOBALS['pc'] = read_error
 
 def b_cont4_12_d(handler, k2):
-    if (False if ((token_type_q(first(value3_reg), symbol_end_marker)) is False) else True):
+    if (token_type_q(first(value3_reg), symbol_end_marker) is not False):
         GLOBALS['value2_reg'] = value4_reg
         GLOBALS['k_reg'] = k2
         GLOBALS['pc'] = apply_cont2
@@ -3522,9 +3602,6 @@ def b_cont4_13_d(src, env2, handler, k):
     GLOBALS['senv_reg'] = initial_contours(env2)
     GLOBALS['adatum_reg'] = value1_reg
     GLOBALS['pc'] = aparse
-
-def apply_fail():
-    Apply((fail_reg).cdr.car, (fail_reg).cdr.cdr)
 
 def b_fail_1_d():
     GLOBALS['final_reg'] = "no more choices"
@@ -3553,15 +3630,9 @@ def b_fail_5_d(exps, env, handler, fail, k):
     GLOBALS['exps_reg'] = (exps).cdr
     GLOBALS['pc'] = eval_choices
 
-def apply_handler():
-    Apply((handler_reg).cdr.car, (handler_reg).cdr.cdr)
-
 def b_handler_1_d():
     GLOBALS['final_reg'] = List(symbol_exception, exception_reg)
     GLOBALS['pc'] = pc_halt_signal
-
-def apply_handler2():
-    Apply((handler_reg).cdr.car, (handler_reg).cdr.cdr)
 
 def b_handler2_1_d():
     GLOBALS['final_reg'] = List(symbol_exception, exception_reg)
@@ -3585,13 +3656,13 @@ def b_handler2_4_d(assertions, right, test_name, verbose, wrong, env, handler, k
     test_exp = aunparse(test_aexp)
     result_exp = (cdr_hat(assert_exp)).cdr.cdr.car
     traceback = get_traceback_string(List(symbol_exception, exception_reg))
-    if (False if ((GreaterThan(string_length(msg), 0)) is False) else True):
-        if (False if (((where) is (symbol_none)) is False) else True):
+    if (GreaterThan(string_length(msg), 0) is not False):
+        if ((where) is (symbol_none) is not False):
             printf("  Error: ~a \"~a\"\n", test_name, msg)
         else:
             printf("  Error: ~a \"~a\" at ~a\n", test_name, msg, where)
     else:
-        if (False if (((where) is (symbol_none)) is False) else True):
+        if ((where) is (symbol_none) is not False):
             printf("  Error: ~a\n", test_name)
         else:
             printf("  Error: ~a at ~a\n", test_name, where)
@@ -3626,14 +3697,11 @@ def b_handler2_7_d(cexps, cvar, fexps, env, handler, k):
     GLOBALS['exps_reg'] = cexps
     GLOBALS['pc'] = eval_sequence
 
-def apply_proc():
-    Apply((proc_reg).cdr.car, (proc_reg).cdr.cdr)
-
 def b_proc_1_d(bodies, formals, env):
     formals_and_args = process_formals_and_args(formals, args_reg, info_reg, handler_reg, fail_reg)
     new_formals = (formals_and_args).car
     new_args = (formals_and_args).cdr
-    if (False if ((numeric_equal(length(new_args), length(new_formals))) is False) else True):
+    if (numeric_equal(length(new_args), length(new_formals)) is not False):
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['env_reg'] = extend(env, new_formals, new_args, make_empty_docstrings(length(new_args)))
         GLOBALS['exps_reg'] = bodies
@@ -3645,7 +3713,7 @@ def b_proc_1_d(bodies, formals, env):
 def b_proc_2_d(bodies, formals, runt, env):
     new_args = args_reg
     new_formals = formals
-    if (False if ((GreaterThanEqual(length(new_args), length(new_formals))) is False) else True):
+    if (GreaterThanEqual(length(new_args), length(new_formals)) is not False):
         new_env = extend(env, cons(runt, new_formals), cons(list_tail(new_args, length(new_formals)), list_head(new_args, length(new_formals))), make_empty_docstrings((1) + (length(new_formals))))
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['env_reg'] = new_env
@@ -3659,7 +3727,7 @@ def b_proc_3_d(bodies, name, trace_depth, formals, env):
     formals_and_args = process_formals_and_args(formals, args_reg, info_reg, handler_reg, fail_reg)
     new_formals = (formals_and_args).car
     new_args = (formals_and_args).cdr
-    if (False if ((numeric_equal(length(new_args), length(new_formals))) is False) else True):
+    if (numeric_equal(length(new_args), length(new_formals)) is not False):
         printf("~acall: ~s~%", make_trace_depth_string(trace_depth), cons(name, new_args))
         GLOBALS['trace_depth'] = (trace_depth) + (1)
         GLOBALS['k_reg'] = make_cont2(b_cont2_94_d, trace_depth, k2_reg)
@@ -3673,7 +3741,7 @@ def b_proc_3_d(bodies, name, trace_depth, formals, env):
 def b_proc_4_d(bodies, name, trace_depth, formals, runt, env):
     new_args = args_reg
     new_formals = formals
-    if (False if ((GreaterThanEqual(length(args_reg), length(new_formals))) is False) else True):
+    if (GreaterThanEqual(length(args_reg), length(new_formals)) is not False):
         new_env = extend(env, cons(runt, new_formals), cons(list_tail(new_args, length(new_formals)), list_head(new_args, length(new_formals))), make_empty_docstrings((1) + (length(new_formals))))
         printf("~acall: ~s~%", make_trace_depth_string(trace_depth), cons(name, new_args))
         GLOBALS['trace_depth'] = (trace_depth) + (1)
@@ -3727,15 +3795,15 @@ def b_proc_11_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_12_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of args to string-join; should be two"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(string_q((args_reg).car))) is False) else True):
+        if (not(string_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = "first arg to string-join must be a string"
             GLOBALS['pc'] = runtime_error
         else:
-            if (False if ((not(list_q((args_reg).cdr.car))) is False) else True):
+            if (not(list_q((args_reg).cdr.car)) is not False):
                 GLOBALS['msg_reg'] = "second arg to string-join must be a list"
                 GLOBALS['pc'] = runtime_error
             else:
@@ -3744,12 +3812,12 @@ def b_proc_12_d():
                 GLOBALS['pc'] = string_join
 
 def b_proc_13_d():
-    if (False if ((length_one_q(args_reg)) is False) else True):
+    if (length_one_q(args_reg) is not False):
         GLOBALS['k_reg'] = make_cont(b_cont_47_d, handler_reg, fail_reg, k2_reg)
         GLOBALS['x_reg'] = (args_reg).car
         GLOBALS['pc'] = annotate_cps
     else:
-        if (False if ((length_two_q(args_reg)) is False) else True):
+        if (length_two_q(args_reg) is not False):
             GLOBALS['k_reg'] = make_cont(b_cont_48_d, args_reg, handler_reg, fail_reg, k2_reg)
             GLOBALS['x_reg'] = (args_reg).car
             GLOBALS['pc'] = annotate_cps
@@ -3758,11 +3826,11 @@ def b_proc_13_d():
             GLOBALS['pc'] = runtime_error
 
 def b_proc_14_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to eval-ast"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(list_q((args_reg).car))) is False) else True):
+        if (not(list_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = "eval-ast called on non-abstract syntax tree argument"
             GLOBALS['pc'] = runtime_error
         else:
@@ -3777,11 +3845,11 @@ def b_proc_15_d():
     GLOBALS['pc'] = annotate_cps
 
 def b_proc_16_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string-length"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(string_q((args_reg).car))) is False) else True):
+        if (not(string_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = "string-length called on non-string argument"
             GLOBALS['pc'] = runtime_error
         else:
@@ -3791,15 +3859,15 @@ def b_proc_16_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_17_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string-ref"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(string_q((args_reg).car))) is False) else True):
+        if (not(string_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = "string-ref called with non-string first argument"
             GLOBALS['pc'] = runtime_error
         else:
-            if (False if ((not(number_q((args_reg).cdr.car))) is False) else True):
+            if (not(number_q((args_reg).cdr.car)) is not False):
                 GLOBALS['msg_reg'] = "string-ref called with non-numberic second argument"
                 GLOBALS['pc'] = runtime_error
             else:
@@ -3835,7 +3903,7 @@ def b_proc_21_d():
 def b_proc_22_d():
     proc_args = (args_reg).cdr.car
     proc = (args_reg).car
-    if (False if ((dlr_proc_q(proc)) is False) else True):
+    if (dlr_proc_q(proc) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = dlr_apply(proc, proc_args)
         GLOBALS['k_reg'] = k2_reg
@@ -3846,7 +3914,7 @@ def b_proc_22_d():
         GLOBALS['pc'] = apply_proc
 
 def b_proc_23_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to sqrt"
         GLOBALS['pc'] = runtime_error
     else:
@@ -3856,7 +3924,7 @@ def b_proc_23_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_24_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to odd?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -3866,7 +3934,7 @@ def b_proc_24_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_25_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to even?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -3876,11 +3944,11 @@ def b_proc_25_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_26_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to quotient"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((member(0, (args_reg).cdr)) is False) else True):
+        if (member(0, (args_reg).cdr) is not False):
             GLOBALS['msg_reg'] = "division by zero"
             GLOBALS['pc'] = runtime_error
         else:
@@ -3890,7 +3958,7 @@ def b_proc_26_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_27_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to remainder"
         GLOBALS['pc'] = runtime_error
     else:
@@ -3913,7 +3981,7 @@ def b_proc_29_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_30_d():
-    if (False if ((numeric_equal(length(args_reg), 3)) is False) else True):
+    if (numeric_equal(length(args_reg), 3) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = substring((args_reg).car, (args_reg).cdr.car, (args_reg).cdr.cdr.car)
         GLOBALS['k_reg'] = k2_reg
@@ -3960,7 +4028,7 @@ def b_proc_35_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_36_d():
-    if (False if ((not(length_at_least_q(1, args_reg))) is False) else True):
+    if (not(length_at_least_q(1, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to load"
         GLOBALS['pc'] = runtime_error
     else:
@@ -3970,7 +4038,7 @@ def b_proc_36_d():
         GLOBALS['pc'] = load_files
 
 def b_proc_37_d():
-    if (False if ((length_one_q(args_reg)) is False) else True):
+    if (length_one_q(args_reg) is not False):
         GLOBALS['ls_reg'] = (args_reg).car
         GLOBALS['sum_reg'] = 0
         GLOBALS['x_reg'] = (args_reg).car
@@ -3980,7 +4048,7 @@ def b_proc_37_d():
         GLOBALS['pc'] = runtime_error
 
 def b_proc_38_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = format("incorrect number of arguments to symbol?: you gave ~s, should have been 1 argument", args_reg)
         GLOBALS['pc'] = runtime_error
     else:
@@ -3990,7 +4058,7 @@ def b_proc_38_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_39_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to number?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4000,7 +4068,7 @@ def b_proc_39_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_40_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to boolean?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4010,7 +4078,7 @@ def b_proc_40_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_41_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4020,7 +4088,7 @@ def b_proc_41_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_42_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to char?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4030,11 +4098,11 @@ def b_proc_42_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_43_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to char=?"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if (((not(char_q((args_reg).car))) or (not(char_q((args_reg).cdr.car)))) is False) else True):
+        if ((not(char_q((args_reg).car))) or (not(char_q((args_reg).cdr.car))) is not False):
             GLOBALS['msg_reg'] = "char=? requires arguments of type char"
             GLOBALS['pc'] = runtime_error
         else:
@@ -4044,7 +4112,7 @@ def b_proc_43_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_44_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to char-whitespace?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4054,7 +4122,7 @@ def b_proc_44_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_45_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to char->integer"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4064,7 +4132,7 @@ def b_proc_45_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_46_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to integer->char"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4074,7 +4142,7 @@ def b_proc_46_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_47_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to char-alphabetic?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4084,7 +4152,7 @@ def b_proc_47_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_48_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to char-numeric?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4094,7 +4162,7 @@ def b_proc_48_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_49_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to null?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4104,7 +4172,7 @@ def b_proc_49_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_50_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to box?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4114,7 +4182,7 @@ def b_proc_50_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_51_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to pair?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4124,7 +4192,7 @@ def b_proc_51_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_52_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to box"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4134,11 +4202,11 @@ def b_proc_52_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_53_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to unbox"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(box_q((args_reg).car))) is False) else True):
+        if (not(box_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("unbox called on non-box ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4148,7 +4216,7 @@ def b_proc_53_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_54_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cons"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4158,11 +4226,11 @@ def b_proc_54_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_55_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to car"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("car called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4172,11 +4240,11 @@ def b_proc_55_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_56_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4186,11 +4254,11 @@ def b_proc_56_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_57_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cadr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(length_at_least_q(2, (args_reg).car))) is False) else True):
+        if (not(length_at_least_q(2, (args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cadr called on incorrect list structure ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4200,11 +4268,11 @@ def b_proc_57_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_58_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caddr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(length_at_least_q(3, (args_reg).car))) is False) else True):
+        if (not(length_at_least_q(3, (args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caddr called on incorrect list structure ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4214,11 +4282,11 @@ def b_proc_58_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_59_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caaaar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caaaar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4228,11 +4296,11 @@ def b_proc_59_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_60_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caaadr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caaadr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4242,11 +4310,11 @@ def b_proc_60_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_61_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caaar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caaar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4256,11 +4324,11 @@ def b_proc_61_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_62_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caadar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caadar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4270,11 +4338,11 @@ def b_proc_62_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_63_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caaddr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caaddr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4284,11 +4352,11 @@ def b_proc_63_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_64_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caadr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caadr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4298,11 +4366,11 @@ def b_proc_64_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_65_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4312,11 +4380,11 @@ def b_proc_65_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_66_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cadaar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cadaar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4326,11 +4394,11 @@ def b_proc_66_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_67_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cadadr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cadadr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4340,11 +4408,11 @@ def b_proc_67_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_68_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cadar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cadar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4354,11 +4422,11 @@ def b_proc_68_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_69_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to caddar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("caddar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4368,11 +4436,11 @@ def b_proc_69_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_70_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cadddr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cadddr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4382,11 +4450,11 @@ def b_proc_70_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_71_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdaaar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdaaar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4396,11 +4464,11 @@ def b_proc_71_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_72_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdaadr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdaadr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4410,11 +4478,11 @@ def b_proc_72_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_73_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdaar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdaar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4424,11 +4492,11 @@ def b_proc_73_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_74_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdadar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdadar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4438,11 +4506,11 @@ def b_proc_74_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_75_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdaddr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdaddr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4452,11 +4520,11 @@ def b_proc_75_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_76_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdadr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdadr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4466,11 +4534,11 @@ def b_proc_76_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_77_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4480,11 +4548,11 @@ def b_proc_77_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_78_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cddaar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cddaar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4494,11 +4562,11 @@ def b_proc_78_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_79_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cddadr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cddadr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4508,11 +4576,11 @@ def b_proc_79_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_80_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cddar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cddar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4522,11 +4590,11 @@ def b_proc_80_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_81_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdddar"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdddar called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4536,11 +4604,11 @@ def b_proc_81_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_82_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cddddr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cddddr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4550,11 +4618,11 @@ def b_proc_82_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_83_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cdddr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cdddr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4564,11 +4632,11 @@ def b_proc_83_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_84_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to cddr"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("cddr called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4584,11 +4652,11 @@ def b_proc_85_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_86_d():
-    if (False if ((not((numeric_equal(length(args_reg), 3)) or (numeric_equal(length(args_reg), 4)))) is False) else True):
+    if (not((numeric_equal(length(args_reg), 3)) or (numeric_equal(length(args_reg), 4))) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to assert"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(procedure_object_q((args_reg).car))) is False) else True):
+        if (not(procedure_object_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = "assertion predicate is not a procedure"
             GLOBALS['pc'] = runtime_error
         else:
@@ -4601,7 +4669,7 @@ def b_proc_86_d():
             GLOBALS['pc'] = apply_proc
 
 def b_proc_87_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to set"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4615,7 +4683,7 @@ def b_proc_88_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_89_d():
-    if (False if ((((args_reg) is symbol_emptylist)) is False) else True):
+    if (((args_reg) is symbol_emptylist) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to -"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4631,7 +4699,7 @@ def b_proc_90_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_91_d():
-    if (False if (((GreaterThan(length(args_reg), 1)) and (member(0, (args_reg).cdr))) is False) else True):
+    if ((GreaterThan(length(args_reg), 1)) and (member(0, (args_reg).cdr)) is not False):
         GLOBALS['msg_reg'] = "division by zero"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4641,11 +4709,11 @@ def b_proc_91_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_92_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to %"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((numeric_equal((args_reg).cdr.car, 0)) is False) else True):
+        if (numeric_equal((args_reg).cdr.car, 0) is not False):
             GLOBALS['msg_reg'] = "modulo by zero"
             GLOBALS['pc'] = runtime_error
         else:
@@ -4667,7 +4735,7 @@ def b_proc_94_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_95_d():
-    if (False if ((not(length_at_least_q(2, args_reg))) is False) else True):
+    if (not(length_at_least_q(2, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to <"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4677,7 +4745,7 @@ def b_proc_95_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_96_d():
-    if (False if ((not(length_at_least_q(2, args_reg))) is False) else True):
+    if (not(length_at_least_q(2, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to >"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4687,7 +4755,7 @@ def b_proc_96_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_97_d():
-    if (False if ((not(length_at_least_q(2, args_reg))) is False) else True):
+    if (not(length_at_least_q(2, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to <="
         GLOBALS['pc'] = runtime_error
     else:
@@ -4697,7 +4765,7 @@ def b_proc_97_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_98_d():
-    if (False if ((not(length_at_least_q(2, args_reg))) is False) else True):
+    if (not(length_at_least_q(2, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to >="
         GLOBALS['pc'] = runtime_error
     else:
@@ -4707,11 +4775,11 @@ def b_proc_98_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_99_d():
-    if (False if ((not(length_at_least_q(2, args_reg))) is False) else True):
+    if (not(length_at_least_q(2, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to ="
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(all_numeric_q(args_reg))) is False) else True):
+        if (not(all_numeric_q(args_reg)) is not False):
             GLOBALS['msg_reg'] = "attempt to apply = on non-numeric argument"
             GLOBALS['pc'] = runtime_error
         else:
@@ -4721,7 +4789,7 @@ def b_proc_99_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_100_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to abs"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4731,7 +4799,7 @@ def b_proc_100_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_101_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to equal?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4741,7 +4809,7 @@ def b_proc_101_d():
         GLOBALS['pc'] = equal_objects_q
 
 def b_proc_102_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to eq?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4751,7 +4819,7 @@ def b_proc_102_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_103_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to memq"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4761,7 +4829,7 @@ def b_proc_103_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_104_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to member"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4772,11 +4840,11 @@ def b_proc_104_d():
         GLOBALS['pc'] = member_loop
 
 def b_proc_105_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to random"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(positive_q((args_reg).car))) is False) else True):
+        if (not(positive_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = "argument to random must be positive"
             GLOBALS['pc'] = runtime_error
         else:
@@ -4786,7 +4854,7 @@ def b_proc_105_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_106_d():
-    if (False if (((((args_reg) is symbol_emptylist)) or (length_at_least_q(4, args_reg))) is False) else True):
+    if ((((args_reg) is symbol_emptylist)) or (length_at_least_q(4, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to range"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4814,11 +4882,11 @@ def b_proc_109_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_110_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to set-car!"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("set-car! called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4828,11 +4896,11 @@ def b_proc_110_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_111_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to set-cdr!"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(pair_q((args_reg).car))) is False) else True):
+        if (not(pair_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("set-cdr! called on non-pair ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4842,7 +4910,7 @@ def b_proc_111_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_112_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to load-as"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4866,17 +4934,17 @@ def b_proc_114_d(k):
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_115_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to call/cc"
         GLOBALS['pc'] = runtime_error
     else:
         proc = (args_reg).car
-        if (False if ((not(procedure_object_q(proc))) is False) else True):
+        if (not(procedure_object_q(proc)) is not False):
             GLOBALS['msg_reg'] = "call/cc called with non-procedure"
             GLOBALS['pc'] = runtime_error
         else:
             fake_k = make_proc(b_proc_114_d, k2_reg)
-            if (False if ((dlr_proc_q(proc)) is False) else True):
+            if (dlr_proc_q(proc) is not False):
                 GLOBALS['value2_reg'] = fail_reg
                 GLOBALS['value1_reg'] = dlr_apply(proc, List(fake_k))
                 GLOBALS['k_reg'] = k2_reg
@@ -4887,7 +4955,7 @@ def b_proc_115_d():
                 GLOBALS['pc'] = apply_proc
 
 def b_proc_116_d():
-    if (False if ((((args_reg) is symbol_emptylist)) is False) else True):
+    if (((args_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = void_value
         GLOBALS['k_reg'] = REP_k
@@ -4899,11 +4967,11 @@ def b_proc_116_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_117_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to require"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((true_q((args_reg).car)) is False) else True):
+        if (true_q((args_reg).car) is not False):
             GLOBALS['value2_reg'] = fail_reg
             GLOBALS['value1_reg'] = symbol_ok
             GLOBALS['k_reg'] = k2_reg
@@ -4918,11 +4986,11 @@ def b_proc_118_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_119_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to reverse"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(list_q(args_reg))) is False) else True):
+        if (not(list_q(args_reg)) is not False):
             GLOBALS['msg_reg'] = format("reverse called on incorrect list structure ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4936,7 +5004,7 @@ def b_proc_120_d():
     GLOBALS['pc'] = append_all
 
 def b_proc_121_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string->number"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4946,7 +5014,7 @@ def b_proc_121_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_122_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string=?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -4956,11 +5024,11 @@ def b_proc_122_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_123_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to list->vector"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(list_q((args_reg).car))) is False) else True):
+        if (not(list_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("list->vector called on incorrect list structure ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -4970,15 +5038,15 @@ def b_proc_123_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_124_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to list->string"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(list_q((args_reg).car))) is False) else True):
+        if (not(list_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("list->string called on incorrect list structure ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
-            if (False if ((not(all_char_q((args_reg).car))) is False) else True):
+            if (not(all_char_q((args_reg).car)) is not False):
                 GLOBALS['msg_reg'] = format("list->string called on non-char list ~s", (args_reg).car)
                 GLOBALS['pc'] = runtime_error
             else:
@@ -4988,11 +5056,11 @@ def b_proc_124_d():
                 GLOBALS['pc'] = apply_cont2
 
 def b_proc_125_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to char->string"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(char_q((args_reg).car))) is False) else True):
+        if (not(char_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("char->string called on non-char item ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -5002,11 +5070,11 @@ def b_proc_125_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_126_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string->list"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(string_q((args_reg).car))) is False) else True):
+        if (not(string_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("string->list called on non-string item ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -5016,11 +5084,11 @@ def b_proc_126_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_127_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string->symbol"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(string_q((args_reg).car))) is False) else True):
+        if (not(string_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("string->symbol called on non-string item ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -5030,11 +5098,11 @@ def b_proc_127_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_128_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to symbol->string"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(symbol_q((args_reg).car))) is False) else True):
+        if (not(symbol_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("symbol->string called on non-symbol item ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -5044,11 +5112,11 @@ def b_proc_128_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_129_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to vector->list"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(vector_q((args_reg).car))) is False) else True):
+        if (not(vector_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("vector->list called on incorrect vector structure ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -5058,11 +5126,11 @@ def b_proc_129_d():
             GLOBALS['pc'] = apply_cont2
 
 def b_proc_130_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to vector-length"
         GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((not(vector_q((args_reg).car))) is False) else True):
+        if (not(vector_q((args_reg).car)) is not False):
             GLOBALS['msg_reg'] = format("vector-length called on incorrect vector structure ~s", (args_reg).car)
             GLOBALS['pc'] = runtime_error
         else:
@@ -5104,7 +5172,7 @@ def b_proc_136_d():
     GLOBALS['pc'] = for_each_primitive
 
 def b_proc_137_d():
-    if (False if ((LessThan(length(args_reg), 1)) is False) else True):
+    if (LessThan(length(args_reg), 1) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to format"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5138,7 +5206,7 @@ def b_proc_141_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_142_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to not"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5180,7 +5248,7 @@ def b_proc_147_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_148_d():
-    if (False if ((not(length_at_least_q(1, args_reg))) is False) else True):
+    if (not(length_at_least_q(1, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to 'error' (should at least 1)"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5190,7 +5258,7 @@ def b_proc_148_d():
         GLOBALS['pc'] = runtime_error
 
 def b_proc_149_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to list-ref"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5200,14 +5268,14 @@ def b_proc_149_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_150_d():
-    if (False if ((((args_reg) is symbol_emptylist)) is False) else True):
+    if (((args_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = current_directory()
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((length_one_q(args_reg)) is False) else True):
-            if (False if ((string_q((args_reg).car)) is False) else True):
+        if (length_one_q(args_reg) is not False):
+            if (string_q((args_reg).car) is not False):
                 GLOBALS['value2_reg'] = fail_reg
                 GLOBALS['value1_reg'] = current_directory((args_reg).car)
                 GLOBALS['k_reg'] = k2_reg
@@ -5220,7 +5288,7 @@ def b_proc_150_d():
             GLOBALS['pc'] = runtime_error
 
 def b_proc_151_d():
-    if (False if (((length_one_q(args_reg)) and (number_q((args_reg).car))) is False) else True):
+    if ((length_one_q(args_reg)) and (number_q((args_reg).car)) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = round((args_reg).car)
         GLOBALS['k_reg'] = k2_reg
@@ -5230,14 +5298,14 @@ def b_proc_151_d():
         GLOBALS['pc'] = runtime_error
 
 def b_proc_152_d():
-    if (False if (((length_one_q(args_reg)) and (boolean_q((args_reg).car))) is False) else True):
+    if ((length_one_q(args_reg)) and (boolean_q((args_reg).car)) is not False):
         set_use_stack_trace_b((args_reg).car)
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = void_value
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((((args_reg) is symbol_emptylist)) is False) else True):
+        if (((args_reg) is symbol_emptylist) is not False):
             GLOBALS['value2_reg'] = fail_reg
             GLOBALS['value1_reg'] = _staruse_stack_trace_star
             GLOBALS['k_reg'] = k2_reg
@@ -5247,14 +5315,14 @@ def b_proc_152_d():
             GLOBALS['pc'] = runtime_error
 
 def b_proc_153_d():
-    if (False if (((length_one_q(args_reg)) and (boolean_q((args_reg).car))) is False) else True):
+    if ((length_one_q(args_reg)) and (boolean_q((args_reg).car)) is not False):
         GLOBALS['_startracing_on_q_star'] = true_q((args_reg).car)
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = void_value
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((((args_reg) is symbol_emptylist)) is False) else True):
+        if (((args_reg) is symbol_emptylist) is not False):
             GLOBALS['value2_reg'] = fail_reg
             GLOBALS['value1_reg'] = _startracing_on_q_star
             GLOBALS['k_reg'] = k2_reg
@@ -5264,7 +5332,7 @@ def b_proc_153_d():
             GLOBALS['pc'] = runtime_error
 
 def b_proc_154_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to eqv?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5274,7 +5342,7 @@ def b_proc_154_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_155_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to vector?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5284,7 +5352,7 @@ def b_proc_155_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_156_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to atom?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5294,7 +5362,7 @@ def b_proc_156_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_157_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to iter?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5342,7 +5410,7 @@ def b_proc_163_d():
     GLOBALS['pc'] = apply_cont2
 
 def b_proc_164_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to list?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5352,7 +5420,7 @@ def b_proc_164_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_165_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to procedure?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5362,7 +5430,7 @@ def b_proc_165_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_166_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string<?"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5372,7 +5440,7 @@ def b_proc_166_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_167_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to float"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5382,7 +5450,7 @@ def b_proc_167_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_168_d():
-    if (False if ((not(((args_reg) is symbol_emptylist))) is False) else True):
+    if (not(((args_reg) is symbol_emptylist)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to globals"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5392,7 +5460,7 @@ def b_proc_168_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_169_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to int"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5402,7 +5470,7 @@ def b_proc_169_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_170_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to assq"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5412,7 +5480,7 @@ def b_proc_170_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_171_d():
-    if (False if ((((args_reg) is symbol_emptylist)) is False) else True):
+    if (((args_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = apply_native(dict, List(symbol_emptylist))
         GLOBALS['k_reg'] = k2_reg
@@ -5423,7 +5491,7 @@ def b_proc_171_d():
         GLOBALS['pc'] = make_dict_tuples
 
 def b_proc_172_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to property"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5433,7 +5501,7 @@ def b_proc_172_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_173_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to rational"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5443,7 +5511,7 @@ def b_proc_173_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_174_d():
-    if (False if ((not(((args_reg) is symbol_emptylist))) is False) else True):
+    if (not(((args_reg) is symbol_emptylist)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to reset-toplevel-env"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5453,14 +5521,14 @@ def b_proc_174_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_175_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to sort"
         GLOBALS['pc'] = runtime_error
     else:
         GLOBALS['pc'] = sort_native
 
 def b_proc_176_d():
-    if (False if ((not(length_at_least_q(2, args_reg))) is False) else True):
+    if (not(length_at_least_q(2, args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string-append"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5470,7 +5538,7 @@ def b_proc_176_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_177_d():
-    if (False if ((not(length_two_q(args_reg))) is False) else True):
+    if (not(length_two_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to string-split"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5480,7 +5548,7 @@ def b_proc_177_d():
         GLOBALS['pc'] = apply_cont2
 
 def b_proc_178_d():
-    if (False if ((not(length_one_q(args_reg))) is False) else True):
+    if (not(length_one_q(args_reg)) is not False):
         GLOBALS['msg_reg'] = "incorrect number of arguments to typeof"
         GLOBALS['pc'] = runtime_error
     else:
@@ -5513,11 +5581,8 @@ def b_proc_182_d(external_function_object):
     GLOBALS['k_reg'] = k2_reg
     GLOBALS['pc'] = apply_cont2
 
-def apply_macro():
-    Apply((macro_reg).cdr.car, (macro_reg).cdr.cdr)
-
 def b_macro_1_d():
-    if (False if ((LessThan(length_hat(datum_reg), 3)) is False) else True):
+    if (LessThan(length_hat(datum_reg), 3) is not False):
         GLOBALS['adatum_reg'] = datum_reg
         GLOBALS['msg_reg'] = "bad lambda expression:"
         GLOBALS['pc'] = aparse_error
@@ -5527,7 +5592,7 @@ def b_macro_1_d():
         return get_internal_defines_hat(bodies, datum_reg, handler_reg, fail_reg, make_cont2(b_cont2_42_d, formals, handler_reg, fail_reg, k_reg))
 
 def b_macro_2_d():
-    if (False if ((LessThan(length_hat(datum_reg), 4)) is False) else True):
+    if (LessThan(length_hat(datum_reg), 4) is not False):
         GLOBALS['adatum_reg'] = datum_reg
         GLOBALS['msg_reg'] = "bad trace-lambda expression:"
         GLOBALS['pc'] = aparse_error
@@ -5538,7 +5603,7 @@ def b_macro_2_d():
         return get_internal_defines_hat(bodies, datum_reg, handler_reg, fail_reg, make_cont2(b_cont2_43_d, name, formals, handler_reg, fail_reg, k_reg))
 
 def b_macro_3_d():
-    if (False if ((symbol_q_hat(cadr_hat(datum_reg))) is False) else True):
+    if (symbol_q_hat(cadr_hat(datum_reg)) is not False):
         name = cadr_hat(datum_reg)
         bindings = caddr_hat(datum_reg)
         vars = map_hat(car_hat, bindings)
@@ -5573,11 +5638,11 @@ def b_macro_5_d():
 
 def b_macro_6_d():
     exps = cdr_hat(datum_reg)
-    if (False if ((null_q_hat(exps)) is False) else True):
+    if (null_q_hat(exps) is not False):
         GLOBALS['value_reg'] = True
         GLOBALS['pc'] = apply_cont
     else:
-        if (False if ((null_q_hat(cdr_hat(exps))) is False) else True):
+        if (null_q_hat(cdr_hat(exps)) is not False):
             GLOBALS['value_reg'] = car_hat(exps)
             GLOBALS['pc'] = apply_cont
         else:
@@ -5586,11 +5651,11 @@ def b_macro_6_d():
 
 def b_macro_7_d():
     exps = cdr_hat(datum_reg)
-    if (False if ((null_q_hat(exps)) is False) else True):
+    if (null_q_hat(exps) is not False):
         GLOBALS['value_reg'] = False
         GLOBALS['pc'] = apply_cont
     else:
-        if (False if ((null_q_hat(cdr_hat(exps))) is False) else True):
+        if (null_q_hat(cdr_hat(exps)) is not False):
             GLOBALS['value_reg'] = car_hat(exps)
             GLOBALS['pc'] = apply_cont
         else:
@@ -5599,63 +5664,63 @@ def b_macro_7_d():
 
 def b_macro_8_d():
     clauses = cdr_hat(datum_reg)
-    if (False if ((null_q_hat(clauses)) is False) else True):
+    if (null_q_hat(clauses) is not False):
         GLOBALS['adatum_reg'] = datum_reg
         GLOBALS['msg_reg'] = "empty (cond) expression"
         GLOBALS['pc'] = amacro_error
     else:
         other_clauses = cdr_hat(clauses)
         first_clause = car_hat(clauses)
-        if (False if (((null_q_hat(first_clause)) or (not(list_q_hat(first_clause)))) is False) else True):
+        if ((null_q_hat(first_clause)) or (not(list_q_hat(first_clause))) is not False):
             GLOBALS['adatum_reg'] = first_clause
             GLOBALS['msg_reg'] = "improper cond clause"
             GLOBALS['pc'] = amacro_error
         else:
             then_exps = cdr_hat(first_clause)
             test_exp = car_hat(first_clause)
-            if (False if ((eq_q_hat(test_exp, symbol_else)) is False) else True):
-                if (False if ((null_q_hat(then_exps)) is False) else True):
+            if (eq_q_hat(test_exp, symbol_else) is not False):
+                if (null_q_hat(then_exps) is not False):
                     GLOBALS['adatum_reg'] = first_clause
                     GLOBALS['msg_reg'] = "improper else clause"
                     GLOBALS['pc'] = amacro_error
                 else:
-                    if (False if ((null_q_hat(cdr_hat(then_exps))) is False) else True):
+                    if (null_q_hat(cdr_hat(then_exps)) is not False):
                         GLOBALS['value_reg'] = car_hat(then_exps)
                         GLOBALS['pc'] = apply_cont
                     else:
                         GLOBALS['value_reg'] = append(List(symbol_begin), at_hat(then_exps))
                         GLOBALS['pc'] = apply_cont
             else:
-                if (False if ((null_q_hat(then_exps)) is False) else True):
-                    if (False if ((null_q_hat(other_clauses)) is False) else True):
+                if (null_q_hat(then_exps) is not False):
+                    if (null_q_hat(other_clauses) is not False):
                         GLOBALS['value_reg'] = append(List(symbol_let), append(List(List(append(List(symbol_bool), List(test_exp)))), List(append(List(symbol_if), append(List(symbol_bool), List(symbol_bool))))))
                         GLOBALS['pc'] = apply_cont
                     else:
                         GLOBALS['value_reg'] = append(List(symbol_let), append(List(append(List(append(List(symbol_bool), List(test_exp))), List(append(List(symbol_else_code), List(append(List(symbol_lambda), append(List(symbol_emptylist), List(append(List(symbol_cond), at_hat(other_clauses)))))))))), List(append(List(symbol_if), append(List(symbol_bool), append(List(symbol_bool), List(List(symbol_else_code))))))))
                         GLOBALS['pc'] = apply_cont
                 else:
-                    if (False if ((eq_q_hat(car_hat(then_exps), symbol__is_to_)) is False) else True):
-                        if (False if ((null_q_hat(cdr_hat(then_exps))) is False) else True):
+                    if (eq_q_hat(car_hat(then_exps), symbol__is_to_) is not False):
+                        if (null_q_hat(cdr_hat(then_exps)) is not False):
                             GLOBALS['adatum_reg'] = first_clause
                             GLOBALS['msg_reg'] = "improper => clause"
                             GLOBALS['pc'] = amacro_error
                         else:
-                            if (False if ((null_q_hat(other_clauses)) is False) else True):
+                            if (null_q_hat(other_clauses) is not False):
                                 GLOBALS['value_reg'] = append(List(symbol_let), append(List(append(List(append(List(symbol_bool), List(test_exp))), List(append(List(symbol_th), List(append(List(symbol_lambda), append(List(symbol_emptylist), List(cadr_hat(then_exps))))))))), List(append(List(symbol_if), append(List(symbol_bool), List(append(List(List(symbol_th)), List(symbol_bool))))))))
                                 GLOBALS['pc'] = apply_cont
                             else:
                                 GLOBALS['value_reg'] = append(List(symbol_let), append(List(append(List(append(List(symbol_bool), List(test_exp))), append(List(append(List(symbol_th), List(append(List(symbol_lambda), append(List(symbol_emptylist), List(cadr_hat(then_exps))))))), List(append(List(symbol_else_code), List(append(List(symbol_lambda), append(List(symbol_emptylist), List(append(List(symbol_cond), at_hat(other_clauses))))))))))), List(append(List(symbol_if), append(List(symbol_bool), append(List(append(List(List(symbol_th)), List(symbol_bool))), List(List(symbol_else_code))))))))
                                 GLOBALS['pc'] = apply_cont
                     else:
-                        if (False if ((null_q_hat(other_clauses)) is False) else True):
-                            if (False if ((null_q_hat(cdr_hat(then_exps))) is False) else True):
+                        if (null_q_hat(other_clauses) is not False):
+                            if (null_q_hat(cdr_hat(then_exps)) is not False):
                                 GLOBALS['value_reg'] = append(List(symbol_if), append(List(test_exp), List(car_hat(then_exps))))
                                 GLOBALS['pc'] = apply_cont
                             else:
                                 GLOBALS['value_reg'] = append(List(symbol_if), append(List(test_exp), List(append(List(symbol_begin), at_hat(then_exps)))))
                                 GLOBALS['pc'] = apply_cont
                         else:
-                            if (False if ((null_q_hat(cdr_hat(then_exps))) is False) else True):
+                            if (null_q_hat(cdr_hat(then_exps)) is not False):
                                 GLOBALS['value_reg'] = append(List(symbol_if), append(List(test_exp), append(List(car_hat(then_exps)), List(append(List(symbol_cond), at_hat(other_clauses))))))
                                 GLOBALS['pc'] = apply_cont
                             else:
@@ -5688,7 +5753,7 @@ def b_macro_11_d():
 def b_macro_12_d():
     datatype_name = cadr_hat(datum_reg)
     type_tester_name = string_to_symbol(string_append(symbol_to_string_hat(datatype_name), "?"))
-    if (False if ((not(eq_q_hat(caddr_hat(datum_reg), type_tester_name))) is False) else True):
+    if (not(eq_q_hat(caddr_hat(datum_reg), type_tester_name)) is not False):
         GLOBALS['adatum_reg'] = caddr_hat(datum_reg)
         GLOBALS['msg_reg'] = format("datatype tester predicate not named ~a", type_tester_name)
         GLOBALS['pc'] = amacro_error
@@ -5731,7 +5796,7 @@ def increment_scan_counters(chars):
     GLOBALS['last_scan_line'] = scan_line
     GLOBALS['last_scan_char'] = scan_char
     GLOBALS['last_scan_position'] = scan_position
-    if (False if ((char_is__q(next_avail(chars), make_char('\n'))) is False) else True):
+    if (char_is__q(next_avail(chars), make_char('\n')) is not False):
         GLOBALS['scan_line'] = (1) + (scan_line)
         GLOBALS['scan_char'] = 1
     else:
@@ -5756,43 +5821,43 @@ def scan_input_loop():
     GLOBALS['pc'] = apply_action
 
 def apply_action():
-    if (False if ((((action_reg).car) is (symbol_shift)) is False) else True):
-        next = list_ref(action_reg, 1)
+    if (((action_reg).car) is (symbol_shift) is not False):
+        next = ((action_reg)).cdr.car
         increment_scan_counters(chars_reg)
         GLOBALS['buffer_reg'] = cons(next_avail(chars_reg), buffer_reg)
         GLOBALS['chars_reg'] = remaining(chars_reg)
         GLOBALS['action_reg'] = next
         GLOBALS['pc'] = apply_action
     else:
-        if (False if ((((action_reg).car) is (symbol_replace)) is False) else True):
-            next = list_ref(action_reg, 2)
-            new_char = list_ref(action_reg, 1)
+        if (((action_reg).car) is (symbol_replace) is not False):
+            next = (((action_reg)).cdr).cdr.car
+            new_char = ((action_reg)).cdr.car
             increment_scan_counters(chars_reg)
             GLOBALS['chars_reg'] = remaining(chars_reg)
             GLOBALS['buffer_reg'] = cons(new_char, buffer_reg)
             GLOBALS['action_reg'] = next
             GLOBALS['pc'] = apply_action
         else:
-            if (False if ((((action_reg).car) is (symbol_drop)) is False) else True):
-                next = list_ref(action_reg, 1)
+            if (((action_reg).car) is (symbol_drop) is not False):
+                next = ((action_reg)).cdr.car
                 increment_scan_counters(chars_reg)
                 GLOBALS['chars_reg'] = remaining(chars_reg)
                 GLOBALS['action_reg'] = next
                 GLOBALS['pc'] = apply_action
             else:
-                if (False if ((((action_reg).car) is (symbol_goto)) is False) else True):
-                    state = list_ref(action_reg, 1)
-                    if (False if (((state) is (symbol_token_start_state)) is False) else True):
+                if (((action_reg).car) is (symbol_goto) is not False):
+                    state = ((action_reg)).cdr.car
+                    if ((state) is (symbol_token_start_state) is not False):
                         mark_token_start()
                     action = apply_state(state, next_avail(chars_reg))
-                    if (False if (((action) is (symbol_error)) is False) else True):
+                    if ((action) is (symbol_error) is not False):
                         GLOBALS['pc'] = unexpected_char_error
                     else:
                         GLOBALS['action_reg'] = action
                         GLOBALS['pc'] = apply_action
                 else:
-                    if (False if ((((action_reg).car) is (symbol_emit)) is False) else True):
-                        token_type = list_ref(action_reg, 1)
+                    if (((action_reg).car) is (symbol_emit) is not False):
+                        token_type = ((action_reg)).cdr.car
                         GLOBALS['k_reg'] = make_cont(b_cont_1_d, chars_reg, fail_reg, k_reg)
                         GLOBALS['token_type_reg'] = token_type
                         GLOBALS['pc'] = convert_buffer_to_token
@@ -5805,7 +5870,7 @@ def scan_error():
 
 def unexpected_char_error():
     c = next_avail(chars_reg)
-    if (False if ((char_is__q(c, make_char('\0'))) is False) else True):
+    if (char_is__q(c, make_char('\0')) is not False):
         GLOBALS['char_reg'] = scan_char
         GLOBALS['line_reg'] = scan_line
         GLOBALS['msg_reg'] = "unexpected end of input"
@@ -5818,65 +5883,65 @@ def unexpected_char_error():
 
 def convert_buffer_to_token():
     buffer = reverse(buffer_reg)
-    if (False if (((token_type_reg) is (symbol_end_marker)) is False) else True):
+    if ((token_type_reg) is (symbol_end_marker) is not False):
         GLOBALS['value_reg'] = make_token1(symbol_end_marker)
         GLOBALS['pc'] = apply_cont
     else:
-        if (False if (((token_type_reg) is (symbol_integer)) is False) else True):
+        if ((token_type_reg) is (symbol_integer) is not False):
             GLOBALS['value_reg'] = make_token2(symbol_integer, list_to_string(buffer))
             GLOBALS['pc'] = apply_cont
         else:
-            if (False if (((token_type_reg) is (symbol_decimal)) is False) else True):
+            if ((token_type_reg) is (symbol_decimal) is not False):
                 GLOBALS['value_reg'] = make_token2(symbol_decimal, list_to_string(buffer))
                 GLOBALS['pc'] = apply_cont
             else:
-                if (False if (((token_type_reg) is (symbol_rational)) is False) else True):
+                if ((token_type_reg) is (symbol_rational) is not False):
                     GLOBALS['value_reg'] = make_token2(symbol_rational, list_to_string(buffer))
                     GLOBALS['pc'] = apply_cont
                 else:
-                    if (False if (((token_type_reg) is (symbol_identifier)) is False) else True):
+                    if ((token_type_reg) is (symbol_identifier) is not False):
                         GLOBALS['value_reg'] = make_token2(symbol_identifier, string_to_symbol(list_to_string(buffer)))
                         GLOBALS['pc'] = apply_cont
                     else:
-                        if (False if (((token_type_reg) is (symbol_boolean)) is False) else True):
+                        if ((token_type_reg) is (symbol_boolean) is not False):
                             GLOBALS['value_reg'] = make_token2(symbol_boolean, (char_is__q((buffer).car, make_char('t'))) or (char_is__q((buffer).car, make_char('T'))))
                             GLOBALS['pc'] = apply_cont
                         else:
-                            if (False if (((token_type_reg) is (symbol_character)) is False) else True):
+                            if ((token_type_reg) is (symbol_character) is not False):
                                 GLOBALS['value_reg'] = make_token2(symbol_character, (buffer).car)
                                 GLOBALS['pc'] = apply_cont
                             else:
-                                if (False if (((token_type_reg) is (symbol_named_character)) is False) else True):
+                                if ((token_type_reg) is (symbol_named_character) is not False):
                                     name = list_to_string(buffer)
-                                    if (False if ((string_is__q(name, "nul")) is False) else True):
+                                    if (string_is__q(name, "nul") is not False):
                                         GLOBALS['value_reg'] = make_token2(symbol_character, make_char('\0'))
                                         GLOBALS['pc'] = apply_cont
                                     else:
-                                        if (False if ((string_is__q(name, "space")) is False) else True):
+                                        if (string_is__q(name, "space") is not False):
                                             GLOBALS['value_reg'] = make_token2(symbol_character, make_char(' '))
                                             GLOBALS['pc'] = apply_cont
                                         else:
-                                            if (False if ((string_is__q(name, "tab")) is False) else True):
+                                            if (string_is__q(name, "tab") is not False):
                                                 GLOBALS['value_reg'] = make_token2(symbol_character, make_char('\t'))
                                                 GLOBALS['pc'] = apply_cont
                                             else:
-                                                if (False if ((string_is__q(name, "newline")) is False) else True):
+                                                if (string_is__q(name, "newline") is not False):
                                                     GLOBALS['value_reg'] = make_token2(symbol_character, make_char('\n'))
                                                     GLOBALS['pc'] = apply_cont
                                                 else:
-                                                    if (False if ((string_is__q(name, "linefeed")) is False) else True):
+                                                    if (string_is__q(name, "linefeed") is not False):
                                                         GLOBALS['value_reg'] = make_token2(symbol_character, make_char('\n'))
                                                         GLOBALS['pc'] = apply_cont
                                                     else:
-                                                        if (False if ((string_is__q(name, "backspace")) is False) else True):
+                                                        if (string_is__q(name, "backspace") is not False):
                                                             GLOBALS['value_reg'] = make_token2(symbol_character, make_char('\b'))
                                                             GLOBALS['pc'] = apply_cont
                                                         else:
-                                                            if (False if ((string_is__q(name, "return")) is False) else True):
+                                                            if (string_is__q(name, "return") is not False):
                                                                 GLOBALS['value_reg'] = make_token2(symbol_character, make_char('\r'))
                                                                 GLOBALS['pc'] = apply_cont
                                                             else:
-                                                                if (False if ((string_is__q(name, "page")) is False) else True):
+                                                                if (string_is__q(name, "page") is not False):
                                                                     GLOBALS['value_reg'] = make_token2(symbol_character, make_char(u"\u000C"))
                                                                     GLOBALS['pc'] = apply_cont
                                                                 else:
@@ -5885,7 +5950,7 @@ def convert_buffer_to_token():
                                                                     GLOBALS['msg_reg'] = format("invalid character name #\\~a", name)
                                                                     GLOBALS['pc'] = scan_error
                                 else:
-                                    if (False if (((token_type_reg) is (symbol_string)) is False) else True):
+                                    if ((token_type_reg) is (symbol_string) is not False):
                                         GLOBALS['value_reg'] = make_token2(symbol_string, list_to_string(buffer))
                                         GLOBALS['pc'] = apply_cont
                                     else:
@@ -5895,7 +5960,7 @@ def convert_buffer_to_token():
 def make_token1(token_type):
     end = List(last_scan_line, last_scan_char, last_scan_position)
     start = List(token_start_line, token_start_char, token_start_position)
-    if (False if (((token_type) is (symbol_end_marker)) is False) else True):
+    if ((token_type) is (symbol_end_marker) is not False):
         return List(token_type, end, end)
     else:
         return List(token_type, start, end)
@@ -5922,7 +5987,7 @@ def get_token_start_pos(token):
     return (get_token_start(token)).cdr.cdr.car
 
 def rac(ls):
-    if (False if (((((ls).cdr) is symbol_emptylist)) is False) else True):
+    if ((((ls).cdr) is symbol_emptylist) is not False):
         return (ls).car
     else:
         current = (ls).cdr
@@ -5931,7 +5996,7 @@ def rac(ls):
         return (current).car
 
 def rdc(ls):
-    if (False if (((((ls).cdr) is symbol_emptylist)) is False) else True):
+    if ((((ls).cdr) is symbol_emptylist) is not False):
         return List()
     else:
         retval = List((ls).car)
@@ -5944,7 +6009,7 @@ def rdc(ls):
         return front
 
 def snoc(x, ls):
-    if (False if ((((ls) is symbol_emptylist)) is False) else True):
+    if (((ls) is symbol_emptylist) is not False):
         return List(x)
     else:
         retval = List((ls).car)
@@ -5976,287 +6041,287 @@ def char_boolean_q(c):
     return (char_is__q(c, make_char('t'))) or (char_is__q(c, make_char('T'))) or (char_is__q(c, make_char('f'))) or (char_is__q(c, make_char('F')))
 
 def apply_state(state, c):
-    if (False if (((state) is (symbol_start_state)) is False) else True):
-        if (False if ((char_whitespace_q(c)) is False) else True):
+    if ((state) is (symbol_start_state) is not False):
+        if (char_whitespace_q(c) is not False):
             return List(symbol_drop, List(symbol_goto, symbol_start_state))
         else:
-            if (False if ((char_is__q(c, make_char(';'))) is False) else True):
+            if (char_is__q(c, make_char(';')) is not False):
                 return List(symbol_drop, List(symbol_goto, symbol_comment_state))
             else:
-                if (False if ((char_is__q(c, make_char('\0'))) is False) else True):
+                if (char_is__q(c, make_char('\0')) is not False):
                     return List(symbol_drop, List(symbol_emit, symbol_end_marker))
                 else:
                     return List(symbol_goto, symbol_token_start_state)
     else:
-        if (False if (((state) is (symbol_token_start_state)) is False) else True):
-            if (False if ((char_is__q(c, make_char('('))) is False) else True):
+        if ((state) is (symbol_token_start_state) is not False):
+            if (char_is__q(c, make_char('(')) is not False):
                 return List(symbol_drop, List(symbol_emit, symbol_lparen))
             else:
-                if (False if ((char_is__q(c, make_char('['))) is False) else True):
+                if (char_is__q(c, make_char('[')) is not False):
                     return List(symbol_drop, List(symbol_emit, symbol_lbracket))
                 else:
-                    if (False if ((char_is__q(c, make_char(')'))) is False) else True):
+                    if (char_is__q(c, make_char(')')) is not False):
                         return List(symbol_drop, List(symbol_emit, symbol_rparen))
                     else:
-                        if (False if ((char_is__q(c, make_char(']'))) is False) else True):
+                        if (char_is__q(c, make_char(']')) is not False):
                             return List(symbol_drop, List(symbol_emit, symbol_rbracket))
                         else:
-                            if (False if ((char_is__q(c, make_char("'"))) is False) else True):
+                            if (char_is__q(c, make_char("'")) is not False):
                                 return List(symbol_drop, List(symbol_emit, symbol_apostrophe))
                             else:
-                                if (False if ((char_is__q(c, make_char('`'))) is False) else True):
+                                if (char_is__q(c, make_char('`')) is not False):
                                     return List(symbol_drop, List(symbol_emit, symbol_backquote))
                                 else:
-                                    if (False if ((char_is__q(c, make_char(','))) is False) else True):
+                                    if (char_is__q(c, make_char(',')) is not False):
                                         return List(symbol_drop, List(symbol_goto, symbol_comma_state))
                                     else:
-                                        if (False if ((char_is__q(c, make_char('#'))) is False) else True):
+                                        if (char_is__q(c, make_char('#')) is not False):
                                             return List(symbol_drop, List(symbol_goto, symbol_hash_prefix_state))
                                         else:
-                                            if (False if ((char_is__q(c, make_char('"'))) is False) else True):
+                                            if (char_is__q(c, make_char('"')) is not False):
                                                 return List(symbol_drop, List(symbol_goto, symbol_string_state))
                                             else:
-                                                if (False if ((char_initial_q(c)) is False) else True):
+                                                if (char_initial_q(c) is not False):
                                                     return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                 else:
-                                                    if (False if ((char_sign_q(c)) is False) else True):
+                                                    if (char_sign_q(c) is not False):
                                                         return List(symbol_shift, List(symbol_goto, symbol_signed_state))
                                                     else:
-                                                        if (False if ((char_is__q(c, make_char('.'))) is False) else True):
+                                                        if (char_is__q(c, make_char('.')) is not False):
                                                             return List(symbol_shift, List(symbol_goto, symbol_decimal_point_state))
                                                         else:
-                                                            if (False if ((char_numeric_q(c)) is False) else True):
+                                                            if (char_numeric_q(c) is not False):
                                                                 return List(symbol_shift, List(symbol_goto, symbol_whole_number_state))
                                                             else:
                                                                 return symbol_error
         else:
-            if (False if (((state) is (symbol_comment_state)) is False) else True):
-                if (False if ((char_is__q(c, make_char('\n'))) is False) else True):
+            if ((state) is (symbol_comment_state) is not False):
+                if (char_is__q(c, make_char('\n')) is not False):
                     return List(symbol_drop, List(symbol_goto, symbol_start_state))
                 else:
-                    if (False if ((char_is__q(c, make_char('\0'))) is False) else True):
+                    if (char_is__q(c, make_char('\0')) is not False):
                         return List(symbol_drop, List(symbol_emit, symbol_end_marker))
                     else:
                         return List(symbol_drop, List(symbol_goto, symbol_comment_state))
             else:
-                if (False if (((state) is (symbol_comma_state)) is False) else True):
-                    if (False if ((char_is__q(c, make_char('@'))) is False) else True):
+                if ((state) is (symbol_comma_state) is not False):
+                    if (char_is__q(c, make_char('@')) is not False):
                         return List(symbol_drop, List(symbol_emit, symbol_comma_at))
                     else:
                         return List(symbol_emit, symbol_comma)
                 else:
-                    if (False if (((state) is (symbol_hash_prefix_state)) is False) else True):
-                        if (False if ((char_boolean_q(c)) is False) else True):
+                    if ((state) is (symbol_hash_prefix_state) is not False):
+                        if (char_boolean_q(c) is not False):
                             return List(symbol_shift, List(symbol_emit, symbol_boolean))
                         else:
-                            if (False if ((char_is__q(c, make_char('\\'))) is False) else True):
+                            if (char_is__q(c, make_char('\\')) is not False):
                                 return List(symbol_drop, List(symbol_goto, symbol_character_state))
                             else:
-                                if (False if ((char_is__q(c, make_char('('))) is False) else True):
+                                if (char_is__q(c, make_char('(')) is not False):
                                     return List(symbol_drop, List(symbol_emit, symbol_lvector))
                                 else:
                                     return symbol_error
                     else:
-                        if (False if (((state) is (symbol_character_state)) is False) else True):
-                            if (False if ((char_alphabetic_q(c)) is False) else True):
+                        if ((state) is (symbol_character_state) is not False):
+                            if (char_alphabetic_q(c) is not False):
                                 return List(symbol_shift, List(symbol_goto, symbol_alphabetic_character_state))
                             else:
-                                if (False if ((not(char_is__q(c, make_char('\0')))) is False) else True):
+                                if (not(char_is__q(c, make_char('\0'))) is not False):
                                     return List(symbol_shift, List(symbol_emit, symbol_character))
                                 else:
                                     return symbol_error
                         else:
-                            if (False if (((state) is (symbol_alphabetic_character_state)) is False) else True):
-                                if (False if ((char_alphabetic_q(c)) is False) else True):
+                            if ((state) is (symbol_alphabetic_character_state) is not False):
+                                if (char_alphabetic_q(c) is not False):
                                     return List(symbol_shift, List(symbol_goto, symbol_named_character_state))
                                 else:
                                     return List(symbol_emit, symbol_character)
                             else:
-                                if (False if (((state) is (symbol_named_character_state)) is False) else True):
-                                    if (False if ((char_delimiter_q(c)) is False) else True):
+                                if ((state) is (symbol_named_character_state) is not False):
+                                    if (char_delimiter_q(c) is not False):
                                         return List(symbol_emit, symbol_named_character)
                                     else:
                                         return List(symbol_shift, List(symbol_goto, symbol_named_character_state))
                                 else:
-                                    if (False if (((state) is (symbol_string_state)) is False) else True):
-                                        if (False if ((char_is__q(c, make_char('"'))) is False) else True):
+                                    if ((state) is (symbol_string_state) is not False):
+                                        if (char_is__q(c, make_char('"')) is not False):
                                             return List(symbol_drop, List(symbol_emit, symbol_string))
                                         else:
-                                            if (False if ((char_is__q(c, make_char('\\'))) is False) else True):
+                                            if (char_is__q(c, make_char('\\')) is not False):
                                                 return List(symbol_drop, List(symbol_goto, symbol_string_escape_state))
                                             else:
-                                                if (False if ((not(char_is__q(c, make_char('\0')))) is False) else True):
+                                                if (not(char_is__q(c, make_char('\0'))) is not False):
                                                     return List(symbol_shift, List(symbol_goto, symbol_string_state))
                                                 else:
                                                     return symbol_error
                                     else:
-                                        if (False if (((state) is (symbol_string_escape_state)) is False) else True):
-                                            if (False if ((char_is__q(c, make_char('"'))) is False) else True):
+                                        if ((state) is (symbol_string_escape_state) is not False):
+                                            if (char_is__q(c, make_char('"')) is not False):
                                                 return List(symbol_shift, List(symbol_goto, symbol_string_state))
                                             else:
-                                                if (False if ((char_is__q(c, make_char('\\'))) is False) else True):
+                                                if (char_is__q(c, make_char('\\')) is not False):
                                                     return List(symbol_shift, List(symbol_goto, symbol_string_state))
                                                 else:
-                                                    if (False if ((char_is__q(c, make_char('b'))) is False) else True):
+                                                    if (char_is__q(c, make_char('b')) is not False):
                                                         return List(symbol_replace, make_char('\b'), List(symbol_goto, symbol_string_state))
                                                     else:
-                                                        if (False if ((char_is__q(c, make_char('f'))) is False) else True):
+                                                        if (char_is__q(c, make_char('f')) is not False):
                                                             return List(symbol_replace, make_char(u"\u000C"), List(symbol_goto, symbol_string_state))
                                                         else:
-                                                            if (False if ((char_is__q(c, make_char('n'))) is False) else True):
+                                                            if (char_is__q(c, make_char('n')) is not False):
                                                                 return List(symbol_replace, make_char('\n'), List(symbol_goto, symbol_string_state))
                                                             else:
-                                                                if (False if ((char_is__q(c, make_char('t'))) is False) else True):
+                                                                if (char_is__q(c, make_char('t')) is not False):
                                                                     return List(symbol_replace, make_char('\t'), List(symbol_goto, symbol_string_state))
                                                                 else:
-                                                                    if (False if ((char_is__q(c, make_char('r'))) is False) else True):
+                                                                    if (char_is__q(c, make_char('r')) is not False):
                                                                         return List(symbol_replace, make_char('\r'), List(symbol_goto, symbol_string_state))
                                                                     else:
                                                                         return symbol_error
                                         else:
-                                            if (False if (((state) is (symbol_identifier_state)) is False) else True):
-                                                if (False if ((char_subsequent_q(c)) is False) else True):
+                                            if ((state) is (symbol_identifier_state) is not False):
+                                                if (char_subsequent_q(c) is not False):
                                                     return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                 else:
-                                                    if (False if ((char_delimiter_q(c)) is False) else True):
+                                                    if (char_delimiter_q(c) is not False):
                                                         return List(symbol_emit, symbol_identifier)
                                                     else:
                                                         return symbol_error
                                             else:
-                                                if (False if (((state) is (symbol_signed_state)) is False) else True):
-                                                    if (False if ((char_numeric_q(c)) is False) else True):
+                                                if ((state) is (symbol_signed_state) is not False):
+                                                    if (char_numeric_q(c) is not False):
                                                         return List(symbol_shift, List(symbol_goto, symbol_whole_number_state))
                                                     else:
-                                                        if (False if ((char_is__q(c, make_char('.'))) is False) else True):
+                                                        if (char_is__q(c, make_char('.')) is not False):
                                                             return List(symbol_shift, List(symbol_goto, symbol_signed_decimal_point_state))
                                                         else:
-                                                            if (False if ((char_delimiter_q(c)) is False) else True):
+                                                            if (char_delimiter_q(c) is not False):
                                                                 return List(symbol_emit, symbol_identifier)
                                                             else:
-                                                                if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                if (char_subsequent_q(c) is not False):
                                                                     return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                 else:
                                                                     return symbol_error
                                                 else:
-                                                    if (False if (((state) is (symbol_decimal_point_state)) is False) else True):
-                                                        if (False if ((char_numeric_q(c)) is False) else True):
+                                                    if ((state) is (symbol_decimal_point_state) is not False):
+                                                        if (char_numeric_q(c) is not False):
                                                             return List(symbol_shift, List(symbol_goto, symbol_fractional_number_state))
                                                         else:
-                                                            if (False if ((char_delimiter_q(c)) is False) else True):
+                                                            if (char_delimiter_q(c) is not False):
                                                                 return List(symbol_emit, symbol_dot)
                                                             else:
-                                                                if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                if (char_subsequent_q(c) is not False):
                                                                     return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                 else:
                                                                     return symbol_error
                                                     else:
-                                                        if (False if (((state) is (symbol_signed_decimal_point_state)) is False) else True):
-                                                            if (False if ((char_numeric_q(c)) is False) else True):
+                                                        if ((state) is (symbol_signed_decimal_point_state) is not False):
+                                                            if (char_numeric_q(c) is not False):
                                                                 return List(symbol_shift, List(symbol_goto, symbol_fractional_number_state))
                                                             else:
-                                                                if (False if ((char_delimiter_q(c)) is False) else True):
+                                                                if (char_delimiter_q(c) is not False):
                                                                     return List(symbol_emit, symbol_identifier)
                                                                 else:
-                                                                    if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                    if (char_subsequent_q(c) is not False):
                                                                         return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                     else:
                                                                         return symbol_error
                                                         else:
-                                                            if (False if (((state) is (symbol_whole_number_state)) is False) else True):
-                                                                if (False if ((char_numeric_q(c)) is False) else True):
+                                                            if ((state) is (symbol_whole_number_state) is not False):
+                                                                if (char_numeric_q(c) is not False):
                                                                     return List(symbol_shift, List(symbol_goto, symbol_whole_number_state))
                                                                 else:
-                                                                    if (False if ((char_is__q(c, make_char('.'))) is False) else True):
+                                                                    if (char_is__q(c, make_char('.')) is not False):
                                                                         return List(symbol_shift, List(symbol_goto, symbol_fractional_number_state))
                                                                     else:
-                                                                        if (False if ((char_is__q(c, make_char('/'))) is False) else True):
+                                                                        if (char_is__q(c, make_char('/')) is not False):
                                                                             return List(symbol_shift, List(symbol_goto, symbol_rational_number_state))
                                                                         else:
-                                                                            if (False if (((char_is__q(c, make_char('e'))) or (char_is__q(c, make_char('E')))) is False) else True):
+                                                                            if ((char_is__q(c, make_char('e'))) or (char_is__q(c, make_char('E'))) is not False):
                                                                                 return List(symbol_shift, List(symbol_goto, symbol_suffix_state))
                                                                             else:
-                                                                                if (False if ((char_delimiter_q(c)) is False) else True):
+                                                                                if (char_delimiter_q(c) is not False):
                                                                                     return List(symbol_emit, symbol_integer)
                                                                                 else:
-                                                                                    if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                                    if (char_subsequent_q(c) is not False):
                                                                                         return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                                     else:
                                                                                         return symbol_error
                                                             else:
-                                                                if (False if (((state) is (symbol_fractional_number_state)) is False) else True):
-                                                                    if (False if ((char_numeric_q(c)) is False) else True):
+                                                                if ((state) is (symbol_fractional_number_state) is not False):
+                                                                    if (char_numeric_q(c) is not False):
                                                                         return List(symbol_shift, List(symbol_goto, symbol_fractional_number_state))
                                                                     else:
-                                                                        if (False if (((char_is__q(c, make_char('e'))) or (char_is__q(c, make_char('E')))) is False) else True):
+                                                                        if ((char_is__q(c, make_char('e'))) or (char_is__q(c, make_char('E'))) is not False):
                                                                             return List(symbol_shift, List(symbol_goto, symbol_suffix_state))
                                                                         else:
-                                                                            if (False if ((char_delimiter_q(c)) is False) else True):
+                                                                            if (char_delimiter_q(c) is not False):
                                                                                 return List(symbol_emit, symbol_decimal)
                                                                             else:
-                                                                                if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                                if (char_subsequent_q(c) is not False):
                                                                                     return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                                 else:
                                                                                     return symbol_error
                                                                 else:
-                                                                    if (False if (((state) is (symbol_rational_number_state)) is False) else True):
-                                                                        if (False if ((char_numeric_q(c)) is False) else True):
+                                                                    if ((state) is (symbol_rational_number_state) is not False):
+                                                                        if (char_numeric_q(c) is not False):
                                                                             return List(symbol_shift, List(symbol_goto, symbol_rational_number_state_star))
                                                                         else:
-                                                                            if (False if ((char_delimiter_q(c)) is False) else True):
+                                                                            if (char_delimiter_q(c) is not False):
                                                                                 return List(symbol_emit, symbol_identifier)
                                                                             else:
-                                                                                if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                                if (char_subsequent_q(c) is not False):
                                                                                     return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                                 else:
                                                                                     return symbol_error
                                                                     else:
-                                                                        if (False if (((state) is (symbol_rational_number_state_star)) is False) else True):
-                                                                            if (False if ((char_numeric_q(c)) is False) else True):
+                                                                        if ((state) is (symbol_rational_number_state_star) is not False):
+                                                                            if (char_numeric_q(c) is not False):
                                                                                 return List(symbol_shift, List(symbol_goto, symbol_rational_number_state_star))
                                                                             else:
-                                                                                if (False if ((char_delimiter_q(c)) is False) else True):
+                                                                                if (char_delimiter_q(c) is not False):
                                                                                     return List(symbol_emit, symbol_rational)
                                                                                 else:
-                                                                                    if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                                    if (char_subsequent_q(c) is not False):
                                                                                         return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                                     else:
                                                                                         return symbol_error
                                                                         else:
-                                                                            if (False if (((state) is (symbol_suffix_state)) is False) else True):
-                                                                                if (False if ((char_sign_q(c)) is False) else True):
+                                                                            if ((state) is (symbol_suffix_state) is not False):
+                                                                                if (char_sign_q(c) is not False):
                                                                                     return List(symbol_shift, List(symbol_goto, symbol_signed_exponent_state))
                                                                                 else:
-                                                                                    if (False if ((char_numeric_q(c)) is False) else True):
+                                                                                    if (char_numeric_q(c) is not False):
                                                                                         return List(symbol_shift, List(symbol_goto, symbol_exponent_state))
                                                                                     else:
-                                                                                        if (False if ((char_delimiter_q(c)) is False) else True):
+                                                                                        if (char_delimiter_q(c) is not False):
                                                                                             return List(symbol_emit, symbol_identifier)
                                                                                         else:
-                                                                                            if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                                            if (char_subsequent_q(c) is not False):
                                                                                                 return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                                             else:
                                                                                                 return symbol_error
                                                                             else:
-                                                                                if (False if (((state) is (symbol_signed_exponent_state)) is False) else True):
-                                                                                    if (False if ((char_numeric_q(c)) is False) else True):
+                                                                                if ((state) is (symbol_signed_exponent_state) is not False):
+                                                                                    if (char_numeric_q(c) is not False):
                                                                                         return List(symbol_shift, List(symbol_goto, symbol_exponent_state))
                                                                                     else:
-                                                                                        if (False if ((char_delimiter_q(c)) is False) else True):
+                                                                                        if (char_delimiter_q(c) is not False):
                                                                                             return List(symbol_emit, symbol_identifier)
                                                                                         else:
-                                                                                            if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                                            if (char_subsequent_q(c) is not False):
                                                                                                 return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                                             else:
                                                                                                 return symbol_error
                                                                                 else:
-                                                                                    if (False if (((state) is (symbol_exponent_state)) is False) else True):
-                                                                                        if (False if ((char_numeric_q(c)) is False) else True):
+                                                                                    if ((state) is (symbol_exponent_state) is not False):
+                                                                                        if (char_numeric_q(c) is not False):
                                                                                             return List(symbol_shift, List(symbol_goto, symbol_exponent_state))
                                                                                         else:
-                                                                                            if (False if ((char_delimiter_q(c)) is False) else True):
+                                                                                            if (char_delimiter_q(c) is not False):
                                                                                                 return List(symbol_emit, symbol_decimal)
                                                                                             else:
-                                                                                                if (False if ((char_subsequent_q(c)) is False) else True):
+                                                                                                if (char_subsequent_q(c) is not False):
                                                                                                     return List(symbol_shift, List(symbol_goto, symbol_identifier_state))
                                                                                                 else:
                                                                                                     return symbol_error
@@ -6342,13 +6407,13 @@ def list_q_hat(asexp):
     return (null_q_hat(asexp)) or ((pair_q_hat(asexp)) and (list_q_hat((asexp).cdr.cdr.car)))
 
 def at_hat(alist):
-    if (False if ((null_q_hat(alist)) is False) else True):
+    if (null_q_hat(alist) is not False):
         return symbol_emptylist
     else:
         return cons(car_hat(alist), at_hat(cdr_hat(alist)))
 
 def length_hat(asexp):
-    if (False if ((null_q_hat(asexp)) is False) else True):
+    if (null_q_hat(asexp) is not False):
         return 0
     else:
         return (1) + (length_hat(cdr_hat(asexp)))
@@ -6357,7 +6422,7 @@ def cons_hat(a, b, info):
     return List(pair_tag, a, b, info)
 
 def map_hat(f_hat, asexp):
-    if (False if ((null_q_hat(asexp)) is False) else True):
+    if (null_q_hat(asexp) is not False):
         return make_null_hat()
     else:
         return cons_hat(f_hat(car_hat(asexp)), map_hat(f_hat, cdr_hat(asexp)), symbol_none)
@@ -6369,15 +6434,15 @@ def list_hat(x):
     return cons_hat(x, make_null_hat(), symbol_none)
 
 def annotate_cps():
-    if (False if ((not(_starreader_generates_annotated_sexps_q_star)) is False) else True):
+    if (not(_starreader_generates_annotated_sexps_q_star) is not False):
         GLOBALS['value_reg'] = x_reg
         GLOBALS['pc'] = apply_cont
     else:
-        if (False if ((annotated_q(x_reg)) is False) else True):
+        if (annotated_q(x_reg) is not False):
             GLOBALS['value_reg'] = x_reg
             GLOBALS['pc'] = apply_cont
         else:
-            if (False if ((pair_q(x_reg)) is False) else True):
+            if (pair_q(x_reg) is not False):
                 GLOBALS['k_reg'] = make_cont(b_cont_3_d, x_reg, info_reg, k_reg)
                 GLOBALS['info_reg'] = symbol_none
                 GLOBALS['x_reg'] = (x_reg).car
@@ -6387,21 +6452,21 @@ def annotate_cps():
                 GLOBALS['pc'] = apply_cont
 
 def unannotate_cps():
-    if (False if ((aatom_q(x_reg)) is False) else True):
+    if (aatom_q(x_reg) is not False):
         GLOBALS['x_reg'] = (x_reg).cdr.car
         GLOBALS['pc'] = unannotate_cps
     else:
-        if (False if ((apair_q(x_reg)) is False) else True):
+        if (apair_q(x_reg) is not False):
             GLOBALS['k_reg'] = make_cont(b_cont_7_d, x_reg, k_reg)
             GLOBALS['x_reg'] = (x_reg).cdr.car
             GLOBALS['pc'] = unannotate_cps
         else:
-            if (False if ((pair_q(x_reg)) is False) else True):
+            if (pair_q(x_reg) is not False):
                 GLOBALS['k_reg'] = make_cont(b_cont_5_d, x_reg, k_reg)
                 GLOBALS['x_reg'] = (x_reg).car
                 GLOBALS['pc'] = unannotate_cps
             else:
-                if (False if ((vector_q(x_reg)) is False) else True):
+                if (vector_q(x_reg) is not False):
                     GLOBALS['k_reg'] = make_cont(b_cont_6_d, k_reg)
                     GLOBALS['x_reg'] = vector_to_list(x_reg)
                     GLOBALS['pc'] = unannotate_cps
@@ -6410,7 +6475,7 @@ def unannotate_cps():
                     GLOBALS['pc'] = apply_cont
 
 def filename_cache(filename):
-    if (False if ((hasitem_native(_starfilename_dict_star, filename)) is False) else True):
+    if (hasitem_native(_starfilename_dict_star, filename) is not False):
         return getitem_native(_starfilename_dict_star, filename)
     else:
         index = vlist_length_native(_starfilename_vector_star)
@@ -6425,49 +6490,49 @@ def make_info(src, start, end):
     return cons(filename_cache(src), append(start, end))
 
 def replace_info(asexp, new_info):
-    if (False if ((atom_q_hat(asexp)) is False) else True):
+    if (atom_q_hat(asexp) is not False):
         return List(atom_tag, (asexp).cdr.car, new_info)
     else:
         return List(pair_tag, (asexp).cdr.car, (asexp).cdr.cdr.car, new_info)
 
 def get_srcfile(info):
-    if (False if (((info) is (symbol_none)) is False) else True):
+    if ((info) is (symbol_none) is not False):
         return symbol_none
     else:
         return get_filename_from_index((info).car)
 
 def get_start_line(info):
-    if (False if (((info) is (symbol_none)) is False) else True):
+    if ((info) is (symbol_none) is not False):
         return symbol_none
     else:
         return (info).cdr.car
 
 def get_start_char(info):
-    if (False if (((info) is (symbol_none)) is False) else True):
+    if ((info) is (symbol_none) is not False):
         return symbol_none
     else:
         return (info).cdr.cdr.car
 
 def get_start_pos(info):
-    if (False if (((info) is (symbol_none)) is False) else True):
+    if ((info) is (symbol_none) is not False):
         return symbol_none
     else:
         return (info).cdr.cdr.cdr.car
 
 def get_end_line(info):
-    if (False if (((info) is (symbol_none)) is False) else True):
+    if ((info) is (symbol_none) is not False):
         return symbol_none
     else:
         return ((info).cdr.cdr.cdr.cdr).car
 
 def get_end_char(info):
-    if (False if (((info) is (symbol_none)) is False) else True):
+    if ((info) is (symbol_none) is not False):
         return symbol_none
     else:
         return ((info).cdr.cdr.cdr.cdr).cdr.car
 
 def get_end_pos(info):
-    if (False if (((info) is (symbol_none)) is False) else True):
+    if ((info) is (symbol_none) is not False):
         return symbol_none
     else:
         return ((info).cdr.cdr.cdr.cdr).cdr.cdr.car
@@ -6495,7 +6560,7 @@ def rest_of(x):
 
 def unexpected_token_error():
     token = first(tokens_reg)
-    if (False if ((token_type_q(token, symbol_end_marker)) is False) else True):
+    if (token_type_q(token, symbol_end_marker) is not False):
         GLOBALS['msg_reg'] = "unexpected end of input"
         GLOBALS['pc'] = read_error
     else:
@@ -6511,24 +6576,24 @@ def read_sexp():
     end = get_token_end(first(tokens_reg))
     start = get_token_start(first(tokens_reg))
     temp_1 = first(tokens_reg)
-    if (False if ((((temp_1).car) is (symbol_integer)) is False) else True):
-        str = list_ref(temp_1, 1)
+    if (((temp_1).car) is (symbol_integer) is not False):
+        str = ((temp_1)).cdr.car
         GLOBALS['k_reg'] = make_cont(b_cont_9_d, end, tokens_reg, fail_reg, k_reg)
         GLOBALS['info_reg'] = make_info(src_reg, start, end)
         GLOBALS['x_reg'] = string_to_integer(str)
         GLOBALS['pc'] = annotate_cps
     else:
-        if (False if ((((temp_1).car) is (symbol_decimal)) is False) else True):
-            str = list_ref(temp_1, 1)
+        if (((temp_1).car) is (symbol_decimal) is not False):
+            str = ((temp_1)).cdr.car
             GLOBALS['k_reg'] = make_cont(b_cont_9_d, end, tokens_reg, fail_reg, k_reg)
             GLOBALS['info_reg'] = make_info(src_reg, start, end)
             GLOBALS['x_reg'] = string_to_decimal(str)
             GLOBALS['pc'] = annotate_cps
         else:
-            if (False if ((((temp_1).car) is (symbol_rational)) is False) else True):
-                str = list_ref(temp_1, 1)
+            if (((temp_1).car) is (symbol_rational) is not False):
+                str = ((temp_1)).cdr.car
                 num = string_to_rational(str)
-                if (False if ((true_q(num)) is False) else True):
+                if (true_q(num) is not False):
                     GLOBALS['k_reg'] = make_cont(b_cont_9_d, end, tokens_reg, fail_reg, k_reg)
                     GLOBALS['info_reg'] = make_info(src_reg, start, end)
                     GLOBALS['x_reg'] = num
@@ -6537,65 +6602,65 @@ def read_sexp():
                     GLOBALS['msg_reg'] = format("cannot represent ~a", str)
                     GLOBALS['pc'] = read_error
             else:
-                if (False if ((((temp_1).car) is (symbol_boolean)) is False) else True):
-                    bool = list_ref(temp_1, 1)
+                if (((temp_1).car) is (symbol_boolean) is not False):
+                    bool = ((temp_1)).cdr.car
                     GLOBALS['k_reg'] = make_cont(b_cont_9_d, end, tokens_reg, fail_reg, k_reg)
                     GLOBALS['info_reg'] = make_info(src_reg, start, end)
                     GLOBALS['x_reg'] = bool
                     GLOBALS['pc'] = annotate_cps
                 else:
-                    if (False if ((((temp_1).car) is (symbol_character)) is False) else True):
-                        char = list_ref(temp_1, 1)
+                    if (((temp_1).car) is (symbol_character) is not False):
+                        char = ((temp_1)).cdr.car
                         GLOBALS['k_reg'] = make_cont(b_cont_9_d, end, tokens_reg, fail_reg, k_reg)
                         GLOBALS['info_reg'] = make_info(src_reg, start, end)
                         GLOBALS['x_reg'] = char
                         GLOBALS['pc'] = annotate_cps
                     else:
-                        if (False if ((((temp_1).car) is (symbol_string)) is False) else True):
-                            str = list_ref(temp_1, 1)
+                        if (((temp_1).car) is (symbol_string) is not False):
+                            str = ((temp_1)).cdr.car
                             GLOBALS['k_reg'] = make_cont(b_cont_9_d, end, tokens_reg, fail_reg, k_reg)
                             GLOBALS['info_reg'] = make_info(src_reg, start, end)
                             GLOBALS['x_reg'] = str
                             GLOBALS['pc'] = annotate_cps
                         else:
-                            if (False if ((((temp_1).car) is (symbol_identifier)) is False) else True):
-                                id = list_ref(temp_1, 1)
+                            if (((temp_1).car) is (symbol_identifier) is not False):
+                                id = ((temp_1)).cdr.car
                                 GLOBALS['k_reg'] = make_cont(b_cont_9_d, end, tokens_reg, fail_reg, k_reg)
                                 GLOBALS['info_reg'] = make_info(src_reg, start, end)
                                 GLOBALS['x_reg'] = id
                                 GLOBALS['pc'] = annotate_cps
                             else:
-                                if (False if ((((temp_1).car) is (symbol_apostrophe)) is False) else True):
+                                if (((temp_1).car) is (symbol_apostrophe) is not False):
                                     GLOBALS['keyword_reg'] = symbol_quote
                                     GLOBALS['pc'] = read_abbreviation
                                 else:
-                                    if (False if ((((temp_1).car) is (symbol_backquote)) is False) else True):
+                                    if (((temp_1).car) is (symbol_backquote) is not False):
                                         GLOBALS['keyword_reg'] = symbol_quasiquote
                                         GLOBALS['pc'] = read_abbreviation
                                     else:
-                                        if (False if ((((temp_1).car) is (symbol_comma)) is False) else True):
+                                        if (((temp_1).car) is (symbol_comma) is not False):
                                             GLOBALS['keyword_reg'] = symbol_unquote
                                             GLOBALS['pc'] = read_abbreviation
                                         else:
-                                            if (False if ((((temp_1).car) is (symbol_comma_at)) is False) else True):
+                                            if (((temp_1).car) is (symbol_comma_at) is not False):
                                                 GLOBALS['keyword_reg'] = symbol_unquote_splicing
                                                 GLOBALS['pc'] = read_abbreviation
                                             else:
-                                                if (False if ((((temp_1).car) is (symbol_lparen)) is False) else True):
+                                                if (((temp_1).car) is (symbol_lparen) is not False):
                                                     tokens = rest_of(tokens_reg)
                                                     GLOBALS['k_reg'] = make_cont4(b_cont4_1_d, src_reg, start, k_reg)
                                                     GLOBALS['expected_terminator_reg'] = symbol_rparen
                                                     GLOBALS['tokens_reg'] = tokens
                                                     GLOBALS['pc'] = read_sexp_sequence
                                                 else:
-                                                    if (False if ((((temp_1).car) is (symbol_lbracket)) is False) else True):
+                                                    if (((temp_1).car) is (symbol_lbracket) is not False):
                                                         tokens = rest_of(tokens_reg)
                                                         GLOBALS['k_reg'] = make_cont4(b_cont4_1_d, src_reg, start, k_reg)
                                                         GLOBALS['expected_terminator_reg'] = symbol_rbracket
                                                         GLOBALS['tokens_reg'] = tokens
                                                         GLOBALS['pc'] = read_sexp_sequence
                                                     else:
-                                                        if (False if ((((temp_1).car) is (symbol_lvector)) is False) else True):
+                                                        if (((temp_1).car) is (symbol_lvector) is not False):
                                                             GLOBALS['k_reg'] = make_cont4(b_cont4_2_d, src_reg, start, k_reg)
                                                             GLOBALS['tokens_reg'] = rest_of(tokens_reg)
                                                             GLOBALS['pc'] = read_vector_sequence
@@ -6612,12 +6677,12 @@ def read_abbreviation():
 
 def read_vector_sequence():
     temp_1 = first(tokens_reg)
-    if (False if ((((temp_1).car) is (symbol_rparen)) is False) else True):
+    if (((temp_1).car) is (symbol_rparen) is not False):
         GLOBALS['expected_terminator_reg'] = symbol_rparen
         GLOBALS['sexps_reg'] = symbol_emptylist
         GLOBALS['pc'] = close_sexp_sequence
     else:
-        if (False if ((((temp_1).car) is (symbol_dot)) is False) else True):
+        if (((temp_1).car) is (symbol_dot) is not False):
             GLOBALS['msg_reg'] = "unexpected dot (.)"
             GLOBALS['pc'] = read_error
         else:
@@ -6626,11 +6691,11 @@ def read_vector_sequence():
 
 def read_sexp_sequence():
     temp_1 = first(tokens_reg)
-    if (False if ((memq((temp_1).car, List(symbol_rparen, symbol_rbracket))) is False) else True):
+    if (memq((temp_1).car, List(symbol_rparen, symbol_rbracket)) is not False):
         GLOBALS['sexps_reg'] = symbol_emptylist
         GLOBALS['pc'] = close_sexp_sequence
     else:
-        if (False if ((((temp_1).car) is (symbol_dot)) is False) else True):
+        if (((temp_1).car) is (symbol_dot) is not False):
             GLOBALS['msg_reg'] = "unexpected dot (.)"
             GLOBALS['pc'] = read_error
         else:
@@ -6640,19 +6705,19 @@ def read_sexp_sequence():
 def close_sexp_sequence():
     end = get_token_end(first(tokens_reg))
     temp_1 = first(tokens_reg)
-    if (False if ((memq((temp_1).car, List(symbol_rparen, symbol_rbracket))) is False) else True):
-        if (False if ((token_type_q(first(tokens_reg), expected_terminator_reg)) is False) else True):
+    if (memq((temp_1).car, List(symbol_rparen, symbol_rbracket)) is not False):
+        if (token_type_q(first(tokens_reg), expected_terminator_reg) is not False):
             GLOBALS['value4_reg'] = fail_reg
             GLOBALS['value3_reg'] = rest_of(tokens_reg)
             GLOBALS['value2_reg'] = end
             GLOBALS['value1_reg'] = sexps_reg
             GLOBALS['pc'] = apply_cont4
         else:
-            if (False if (((expected_terminator_reg) is (symbol_rparen)) is False) else True):
+            if ((expected_terminator_reg) is (symbol_rparen) is not False):
                 GLOBALS['msg_reg'] = "parenthesized list terminated by bracket"
                 GLOBALS['pc'] = read_error
             else:
-                if (False if (((expected_terminator_reg) is (symbol_rbracket)) is False) else True):
+                if ((expected_terminator_reg) is (symbol_rbracket) is not False):
                     GLOBALS['msg_reg'] = "bracketed list terminated by parenthesis"
                     GLOBALS['pc'] = read_error
     else:
@@ -6672,9 +6737,6 @@ def set_binding_value_b(binding, value):
 
 def set_binding_docstring_b(binding, docstring):
     set_cdr_b(binding, docstring)
-
-def make_frame(variables, values, docstrings):
-    return List(list_to_vector(Map(make_binding, values, docstrings)), variables)
 
 def empty_frame_q(frame):
     return (((frame).cdr.car) is symbol_emptylist)
@@ -6703,11 +6765,6 @@ def initial_contours(env):
 def frames(env):
     return (env).cdr
 
-def add_binding(new_var, new_binding, frame):
-    vars = (frame).cdr.car
-    bindings = vector_to_list((frame).car)
-    return List(list_to_vector(append(bindings, List(new_binding))), append(vars, List(new_var)))
-
 def set_first_frame_b(env, new_frame):
     set_car_b((env).cdr, new_frame)
 
@@ -6718,11 +6775,11 @@ def search_env(env, variable):
     return search_frames((env).cdr, variable)
 
 def search_frames(frames, variable):
-    if (False if ((((frames) is symbol_emptylist)) is False) else True):
+    if (((frames) is symbol_emptylist) is not False):
         return False
     else:
         binding = search_frame((frames).car, variable)
-        if (False if ((binding) is False) else True):
+        if (binding is not False):
             return binding
         else:
             return search_frames((frames).cdr, variable)
@@ -6753,27 +6810,27 @@ def lookup_value():
 
 def lookup_variable():
     binding = search_env(env_reg, var_reg)
-    if (False if ((binding) is False) else True):
+    if (binding is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = binding
         GLOBALS['k_reg'] = sk_reg
         GLOBALS['pc'] = apply_cont2
     else:
         components = split_variable(var_reg)
-        if (False if ((((((components).cdr) is symbol_emptylist)) and (dlr_env_contains((components).car))) is False) else True):
+        if (((((components).cdr) is symbol_emptylist)) and (dlr_env_contains((components).car)) is not False):
             GLOBALS['value2_reg'] = fail_reg
             GLOBALS['value1_reg'] = (components).car
             GLOBALS['k_reg'] = gk_reg
             GLOBALS['pc'] = apply_cont2
         else:
-            if (False if (((not((((components).cdr) is symbol_emptylist))) and (dlr_env_contains((components).car)) and (dlr_object_contains(dlr_env_lookup((components).car), components))) is False) else True):
+            if ((not((((components).cdr) is symbol_emptylist))) and (dlr_env_contains((components).car)) and (dlr_object_contains(dlr_env_lookup((components).car), components)) is not False):
                 GLOBALS['value3_reg'] = fail_reg
                 GLOBALS['value2_reg'] = components
                 GLOBALS['value1_reg'] = dlr_env_lookup((components).car)
                 GLOBALS['k_reg'] = dk_reg
                 GLOBALS['pc'] = apply_cont3
             else:
-                if (False if (((((components).cdr) is symbol_emptylist)) is False) else True):
+                if ((((components).cdr) is symbol_emptylist) is not False):
                     GLOBALS['info_reg'] = var_info_reg
                     GLOBALS['msg_reg'] = format("unbound variable '~a'", var_reg)
                     GLOBALS['pc'] = runtime_error
@@ -6786,8 +6843,8 @@ def lookup_variable():
 def lookup_variable_components():
     var = (components_reg).car
     binding = search_env(module_reg, var)
-    if (False if ((binding) is False) else True):
-        if (False if (((((components_reg).cdr) is symbol_emptylist)) is False) else True):
+    if (binding is not False):
+        if ((((components_reg).cdr) is symbol_emptylist) is not False):
             GLOBALS['value2_reg'] = fail_reg
             GLOBALS['value1_reg'] = binding
             GLOBALS['k_reg'] = sk_reg
@@ -6795,13 +6852,13 @@ def lookup_variable_components():
         else:
             new_path = (format("~a", var) if string_is__q(path_reg, "") else format("~a.~a", path_reg, var))
             value = binding_value(binding)
-            if (False if ((environment_q(value)) is False) else True):
+            if (environment_q(value) is not False):
                 GLOBALS['module_reg'] = value
                 GLOBALS['path_reg'] = new_path
                 GLOBALS['components_reg'] = (components_reg).cdr
                 GLOBALS['pc'] = lookup_variable_components
             else:
-                if (False if ((dlr_object_contains(value, components_reg)) is False) else True):
+                if (dlr_object_contains(value, components_reg) is not False):
                     GLOBALS['value3_reg'] = fail_reg
                     GLOBALS['value2_reg'] = components_reg
                     GLOBALS['value1_reg'] = value
@@ -6812,7 +6869,7 @@ def lookup_variable_components():
                     GLOBALS['msg_reg'] = format("'~a' is not a module", new_path)
                     GLOBALS['pc'] = runtime_error
     else:
-        if (False if ((string_is__q(path_reg, "")) is False) else True):
+        if (string_is__q(path_reg, "") is not False):
             GLOBALS['info_reg'] = var_info_reg
             GLOBALS['msg_reg'] = format("undefined item in '~a'", var)
             GLOBALS['pc'] = runtime_error
@@ -6824,7 +6881,7 @@ def lookup_variable_components():
 def lookup_binding_in_first_frame():
     frame = first_frame(env_reg)
     binding = search_frame(frame, var_reg)
-    if (False if ((binding) is False) else True):
+    if (binding is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = binding
         GLOBALS['pc'] = apply_cont2
@@ -6838,7 +6895,7 @@ def lookup_binding_in_first_frame():
 
 def split_variable(var):
     strings = string_split(symbol_to_string(var), make_char('.'))
-    if (False if ((member("", strings)) is False) else True):
+    if (member("", strings) is not False):
         return symbol_emptylist
     else:
         return Map(string_to_symbol, strings)
@@ -6847,25 +6904,25 @@ def id_q(exp):
     return (symbol_q(exp)) or (association_q(exp))
 
 def head(formals):
-    if (False if ((symbol_q(formals)) is False) else True):
+    if (symbol_q(formals) is not False):
         return symbol_emptylist
     else:
-        if (False if ((association_q(formals)) is False) else True):
+        if (association_q(formals) is not False):
             return symbol_emptylist
         else:
-            if (False if ((pair_q((formals).cdr)) is False) else True):
+            if (pair_q((formals).cdr) is not False):
                 return cons((formals).car, head((formals).cdr))
             else:
                 return List((formals).car)
 
 def last(formals):
-    if (False if ((symbol_q(formals)) is False) else True):
+    if (symbol_q(formals) is not False):
         return formals
     else:
-        if (False if ((association_q(formals)) is False) else True):
+        if (association_q(formals) is not False):
             return formals
         else:
-            if (False if ((pair_q((formals).cdr)) is False) else True):
+            if (pair_q((formals).cdr) is not False):
                 return last((formals).cdr)
             else:
                 return (formals).cdr
@@ -6920,13 +6977,13 @@ def try_catch_finally_exps_hat(x):
 
 def aparse():
     info = get_source_info(adatum_reg)
-    if (False if ((literal_q_hat(adatum_reg)) is False) else True):
+    if (literal_q_hat(adatum_reg) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = lit_aexp(untag_atom_hat(adatum_reg), info)
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((symbol_q_hat(adatum_reg)) is False) else True):
-            if (False if ((_staruse_lexical_address_star) is False) else True):
+        if (symbol_q_hat(adatum_reg) is not False):
+            if (_staruse_lexical_address_star is not False):
                 GLOBALS['info_reg'] = info
                 GLOBALS['depth_reg'] = 0
                 GLOBALS['id_reg'] = untag_atom_hat(adatum_reg)
@@ -6936,83 +6993,83 @@ def aparse():
                 GLOBALS['value1_reg'] = var_aexp(untag_atom_hat(adatum_reg), info)
                 GLOBALS['pc'] = apply_cont2
         else:
-            if (False if ((vector_q_hat(adatum_reg)) is False) else True):
+            if (vector_q_hat(adatum_reg) is not False):
                 GLOBALS['k_reg'] = make_cont(b_cont_19_d, info, fail_reg, k_reg)
                 GLOBALS['x_reg'] = adatum_reg
                 GLOBALS['pc'] = unannotate_cps
             else:
-                if (False if ((quote_q_hat(adatum_reg)) is False) else True):
+                if (quote_q_hat(adatum_reg) is not False):
                     GLOBALS['k_reg'] = make_cont(b_cont_20_d, info, fail_reg, k_reg)
                     GLOBALS['x_reg'] = adatum_reg
                     GLOBALS['pc'] = unannotate_cps
                 else:
-                    if (False if ((quasiquote_q_hat(adatum_reg)) is False) else True):
+                    if (quasiquote_q_hat(adatum_reg) is not False):
                         GLOBALS['k_reg'] = make_cont(b_cont_18_d, adatum_reg, senv_reg, info, handler_reg, fail_reg, k_reg)
                         GLOBALS['depth_reg'] = 0
                         GLOBALS['ax_reg'] = cadr_hat(adatum_reg)
                         GLOBALS['pc'] = qq_expand_cps
                     else:
-                        if (False if ((unquote_q_hat(adatum_reg)) is False) else True):
+                        if (unquote_q_hat(adatum_reg) is not False):
                             GLOBALS['msg_reg'] = "misplaced"
                             GLOBALS['pc'] = aparse_error
                         else:
-                            if (False if ((unquote_splicing_q_hat(adatum_reg)) is False) else True):
+                            if (unquote_splicing_q_hat(adatum_reg) is not False):
                                 GLOBALS['msg_reg'] = "misplaced"
                                 GLOBALS['pc'] = aparse_error
                             else:
-                                if (False if ((syntactic_sugar_q_hat(adatum_reg)) is False) else True):
+                                if (syntactic_sugar_q_hat(adatum_reg) is not False):
                                     GLOBALS['k_reg'] = make_cont2(b_cont2_35_d, senv_reg, handler_reg, k_reg)
                                     GLOBALS['pc'] = expand_once_hat
                                 else:
-                                    if (False if ((if_then_q_hat(adatum_reg)) is False) else True):
+                                    if (if_then_q_hat(adatum_reg) is not False):
                                         GLOBALS['k_reg'] = make_cont2(b_cont2_31_d, adatum_reg, senv_reg, info, handler_reg, k_reg)
                                         GLOBALS['adatum_reg'] = cadr_hat(adatum_reg)
                                         GLOBALS['pc'] = aparse
                                     else:
-                                        if (False if ((if_else_q_hat(adatum_reg)) is False) else True):
+                                        if (if_else_q_hat(adatum_reg) is not False):
                                             GLOBALS['k_reg'] = make_cont2(b_cont2_34_d, adatum_reg, senv_reg, info, handler_reg, k_reg)
                                             GLOBALS['adatum_reg'] = cadr_hat(adatum_reg)
                                             GLOBALS['pc'] = aparse
                                         else:
-                                            if (False if ((help_q_hat(adatum_reg)) is False) else True):
+                                            if (help_q_hat(adatum_reg) is not False):
                                                 var_info = get_source_info(cadr_hat(adatum_reg))
                                                 GLOBALS['value2_reg'] = fail_reg
                                                 GLOBALS['value1_reg'] = help_aexp(untag_atom_hat(cadr_hat(adatum_reg)), var_info, info)
                                                 GLOBALS['pc'] = apply_cont2
                                             else:
-                                                if (False if ((assignment_q_hat(adatum_reg)) is False) else True):
+                                                if (assignment_q_hat(adatum_reg) is not False):
                                                     GLOBALS['k_reg'] = make_cont2(b_cont2_29_d, adatum_reg, info, k_reg)
                                                     GLOBALS['adatum_reg'] = caddr_hat(adatum_reg)
                                                     GLOBALS['pc'] = aparse
                                                 else:
-                                                    if (False if ((association_q_hat(adatum_reg)) is False) else True):
+                                                    if (association_q_hat(adatum_reg) is not False):
                                                         GLOBALS['k_reg'] = make_cont2(b_cont2_27_d, adatum_reg, info, k_reg)
                                                         GLOBALS['adatum_reg'] = caddr_hat(adatum_reg)
                                                         GLOBALS['pc'] = aparse
                                                     else:
-                                                        if (False if ((func_q_hat(adatum_reg)) is False) else True):
+                                                        if (func_q_hat(adatum_reg) is not False):
                                                             GLOBALS['k_reg'] = make_cont2(b_cont2_28_d, info, k_reg)
                                                             GLOBALS['adatum_reg'] = cadr_hat(adatum_reg)
                                                             GLOBALS['pc'] = aparse
                                                         else:
-                                                            if (False if ((callback_q_hat(adatum_reg)) is False) else True):
+                                                            if (callback_q_hat(adatum_reg) is not False):
                                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_24_d, info, k_reg)
                                                                 GLOBALS['adatum_reg'] = cadr_hat(adatum_reg)
                                                                 GLOBALS['pc'] = aparse
                                                             else:
-                                                                if (False if ((define_q_hat(adatum_reg)) is False) else True):
-                                                                    if (False if ((mit_style_define_q_hat(adatum_reg)) is False) else True):
+                                                                if (define_q_hat(adatum_reg) is not False):
+                                                                    if (mit_style_define_q_hat(adatum_reg) is not False):
                                                                         GLOBALS['k_reg'] = make_cont(b_cont_15_d, senv_reg, info, handler_reg, fail_reg, k_reg)
                                                                         GLOBALS['datum_reg'] = adatum_reg
                                                                         GLOBALS['macro_reg'] = mit_define_transformer_hat
                                                                         GLOBALS['pc'] = apply_macro
                                                                     else:
-                                                                        if (False if (((numeric_equal(length_hat(adatum_reg), 3)) and (symbol_q_hat(cadr_hat(adatum_reg)))) is False) else True):
+                                                                        if ((numeric_equal(length_hat(adatum_reg), 3)) and (symbol_q_hat(cadr_hat(adatum_reg))) is not False):
                                                                             GLOBALS['k_reg'] = make_cont2(b_cont2_26_d, adatum_reg, info, k_reg)
                                                                             GLOBALS['adatum_reg'] = caddr_hat(adatum_reg)
                                                                             GLOBALS['pc'] = aparse
                                                                         else:
-                                                                            if (False if (((numeric_equal(length_hat(adatum_reg), 4)) and (symbol_q_hat(cadr_hat(adatum_reg))) and (string_q_hat(caddr_hat(adatum_reg)))) is False) else True):
+                                                                            if ((numeric_equal(length_hat(adatum_reg), 4)) and (symbol_q_hat(cadr_hat(adatum_reg))) and (string_q_hat(caddr_hat(adatum_reg))) is not False):
                                                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_25_d, adatum_reg, info, k_reg)
                                                                                 GLOBALS['adatum_reg'] = cadddr_hat(adatum_reg)
                                                                                 GLOBALS['pc'] = aparse
@@ -7020,19 +7077,19 @@ def aparse():
                                                                                 GLOBALS['msg_reg'] = "bad concrete syntax:"
                                                                                 GLOBALS['pc'] = aparse_error
                                                                 else:
-                                                                    if (False if ((define_b_q_hat(adatum_reg)) is False) else True):
-                                                                        if (False if ((mit_style_define_q_hat(adatum_reg)) is False) else True):
+                                                                    if (define_b_q_hat(adatum_reg) is not False):
+                                                                        if (mit_style_define_q_hat(adatum_reg) is not False):
                                                                             GLOBALS['k_reg'] = make_cont(b_cont_15_d, senv_reg, info, handler_reg, fail_reg, k_reg)
                                                                             GLOBALS['datum_reg'] = adatum_reg
                                                                             GLOBALS['macro_reg'] = mit_define_transformer_hat
                                                                             GLOBALS['pc'] = apply_macro
                                                                         else:
-                                                                            if (False if ((numeric_equal(length_hat(adatum_reg), 3)) is False) else True):
+                                                                            if (numeric_equal(length_hat(adatum_reg), 3) is not False):
                                                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_22_d, adatum_reg, info, k_reg)
                                                                                 GLOBALS['adatum_reg'] = caddr_hat(adatum_reg)
                                                                                 GLOBALS['pc'] = aparse
                                                                             else:
-                                                                                if (False if (((numeric_equal(length_hat(adatum_reg), 4)) and (string_q_hat(caddr_hat(adatum_reg)))) is False) else True):
+                                                                                if ((numeric_equal(length_hat(adatum_reg), 4)) and (string_q_hat(caddr_hat(adatum_reg))) is not False):
                                                                                     GLOBALS['k_reg'] = make_cont2(b_cont2_21_d, adatum_reg, info, k_reg)
                                                                                     GLOBALS['adatum_reg'] = cadddr_hat(adatum_reg)
                                                                                     GLOBALS['pc'] = aparse
@@ -7040,9 +7097,9 @@ def aparse():
                                                                                     GLOBALS['msg_reg'] = "bad concrete syntax:"
                                                                                     GLOBALS['pc'] = aparse_error
                                                                     else:
-                                                                        if (False if ((define_syntax_q_hat(adatum_reg)) is False) else True):
+                                                                        if (define_syntax_q_hat(adatum_reg) is not False):
                                                                             name = define_var_hat(adatum_reg)
-                                                                            if (False if ((lambda_q_hat(caddr_hat(adatum_reg))) is False) else True):
+                                                                            if (lambda_q_hat(caddr_hat(adatum_reg)) is not False):
                                                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_23_d, name, info, k_reg)
                                                                                 GLOBALS['adatum_reg'] = caddr_hat(adatum_reg)
                                                                                 GLOBALS['pc'] = aparse
@@ -7052,21 +7109,21 @@ def aparse():
                                                                                 GLOBALS['x_reg'] = aclauses
                                                                                 GLOBALS['pc'] = unannotate_cps
                                                                         else:
-                                                                            if (False if ((define_tests_q_hat(adatum_reg)) is False) else True):
+                                                                            if (define_tests_q_hat(adatum_reg) is not False):
                                                                                 aclauses = cddr_hat(adatum_reg)
                                                                                 name = define_var_hat(adatum_reg)
                                                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_19_d, name, info, k_reg)
                                                                                 GLOBALS['adatum_list_reg'] = aclauses
                                                                                 GLOBALS['pc'] = aparse_all
                                                                             else:
-                                                                                if (False if ((run_tests_q_hat(adatum_reg)) is False) else True):
+                                                                                if (run_tests_q_hat(adatum_reg) is not False):
                                                                                     args = cdr_hat(adatum_reg)
-                                                                                    if (False if ((null_q_hat(args)) is False) else True):
+                                                                                    if (null_q_hat(args) is not False):
                                                                                         GLOBALS['value2_reg'] = fail_reg
                                                                                         GLOBALS['value1_reg'] = run_tests_aexp(symbol_emptylist)
                                                                                         GLOBALS['pc'] = apply_cont2
                                                                                     else:
-                                                                                        if (False if (((symbol_q_hat(car_hat(args))) and (list_of_test_groups_q_hat(cdr_hat(args)))) is False) else True):
+                                                                                        if ((symbol_q_hat(car_hat(args))) and (list_of_test_groups_q_hat(cdr_hat(args))) is not False):
                                                                                             GLOBALS['k_reg'] = make_cont2(b_cont2_20_d, k_reg)
                                                                                             GLOBALS['args_reg'] = list_hat(args)
                                                                                             GLOBALS['pc'] = aparse_unit_tests
@@ -7075,12 +7132,12 @@ def aparse():
                                                                                             GLOBALS['args_reg'] = args
                                                                                             GLOBALS['pc'] = aparse_unit_tests
                                                                                 else:
-                                                                                    if (False if ((begin_q_hat(adatum_reg)) is False) else True):
-                                                                                        if (False if ((null_q_hat(cdr_hat(adatum_reg))) is False) else True):
+                                                                                    if (begin_q_hat(adatum_reg) is not False):
+                                                                                        if (null_q_hat(cdr_hat(adatum_reg)) is not False):
                                                                                             GLOBALS['msg_reg'] = "bad concrete syntax:"
                                                                                             GLOBALS['pc'] = aparse_error
                                                                                         else:
-                                                                                            if (False if ((null_q_hat(cddr_hat(adatum_reg))) is False) else True):
+                                                                                            if (null_q_hat(cddr_hat(adatum_reg)) is not False):
                                                                                                 GLOBALS['adatum_reg'] = cadr_hat(adatum_reg)
                                                                                                 GLOBALS['pc'] = aparse
                                                                                             else:
@@ -7088,28 +7145,28 @@ def aparse():
                                                                                                 GLOBALS['adatum_list_reg'] = cdr_hat(adatum_reg)
                                                                                                 GLOBALS['pc'] = aparse_all
                                                                                     else:
-                                                                                        if (False if ((lambda_no_defines_q_hat(adatum_reg)) is False) else True):
+                                                                                        if (lambda_no_defines_q_hat(adatum_reg) is not False):
                                                                                             GLOBALS['k_reg'] = make_cont(b_cont_13_d, adatum_reg, senv_reg, info, handler_reg, fail_reg, k_reg)
                                                                                             GLOBALS['x_reg'] = cadr_hat(adatum_reg)
                                                                                             GLOBALS['pc'] = unannotate_cps
                                                                                         else:
-                                                                                            if (False if ((trace_lambda_no_defines_q_hat(adatum_reg)) is False) else True):
+                                                                                            if (trace_lambda_no_defines_q_hat(adatum_reg) is not False):
                                                                                                 GLOBALS['k_reg'] = make_cont(b_cont_12_d, adatum_reg, senv_reg, info, handler_reg, fail_reg, k_reg)
                                                                                                 GLOBALS['x_reg'] = caddr_hat(adatum_reg)
                                                                                                 GLOBALS['pc'] = unannotate_cps
                                                                                             else:
-                                                                                                if (False if ((try_q_hat(adatum_reg)) is False) else True):
-                                                                                                    if (False if (((numeric_equal(length_hat(adatum_reg), 3)) and (catch_q_hat(caddr_hat(adatum_reg)))) is False) else True):
+                                                                                                if (try_q_hat(adatum_reg) is not False):
+                                                                                                    if ((numeric_equal(length_hat(adatum_reg), 3)) and (catch_q_hat(caddr_hat(adatum_reg))) is not False):
                                                                                                         GLOBALS['k_reg'] = make_cont2(b_cont2_14_d, adatum_reg, senv_reg, info, handler_reg, k_reg)
                                                                                                         GLOBALS['adatum_reg'] = try_body_hat(adatum_reg)
                                                                                                         GLOBALS['pc'] = aparse
                                                                                                     else:
-                                                                                                        if (False if (((numeric_equal(length_hat(adatum_reg), 3)) and (finally_q_hat(caddr_hat(adatum_reg)))) is False) else True):
+                                                                                                        if ((numeric_equal(length_hat(adatum_reg), 3)) and (finally_q_hat(caddr_hat(adatum_reg))) is not False):
                                                                                                             GLOBALS['k_reg'] = make_cont2(b_cont2_16_d, adatum_reg, senv_reg, info, handler_reg, k_reg)
                                                                                                             GLOBALS['adatum_reg'] = try_body_hat(adatum_reg)
                                                                                                             GLOBALS['pc'] = aparse
                                                                                                         else:
-                                                                                                            if (False if (((numeric_equal(length_hat(adatum_reg), 4)) and (catch_q_hat(caddr_hat(adatum_reg))) and (finally_q_hat(cadddr_hat(adatum_reg)))) is False) else True):
+                                                                                                            if ((numeric_equal(length_hat(adatum_reg), 4)) and (catch_q_hat(caddr_hat(adatum_reg))) and (finally_q_hat(cadddr_hat(adatum_reg))) is not False):
                                                                                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_12_d, adatum_reg, senv_reg, info, handler_reg, k_reg)
                                                                                                                 GLOBALS['adatum_reg'] = try_body_hat(adatum_reg)
                                                                                                                 GLOBALS['pc'] = aparse
@@ -7117,17 +7174,17 @@ def aparse():
                                                                                                                 GLOBALS['msg_reg'] = "bad try syntax:"
                                                                                                                 GLOBALS['pc'] = aparse_error
                                                                                                 else:
-                                                                                                    if (False if ((raise_q_hat(adatum_reg)) is False) else True):
+                                                                                                    if (raise_q_hat(adatum_reg) is not False):
                                                                                                         GLOBALS['k_reg'] = make_cont2(b_cont2_7_d, info, k_reg)
                                                                                                         GLOBALS['adatum_reg'] = cadr_hat(adatum_reg)
                                                                                                         GLOBALS['pc'] = aparse
                                                                                                     else:
-                                                                                                        if (False if ((choose_q_hat(adatum_reg)) is False) else True):
+                                                                                                        if (choose_q_hat(adatum_reg) is not False):
                                                                                                             GLOBALS['k_reg'] = make_cont2(b_cont2_8_d, info, k_reg)
                                                                                                             GLOBALS['adatum_list_reg'] = cdr_hat(adatum_reg)
                                                                                                             GLOBALS['pc'] = aparse_all
                                                                                                         else:
-                                                                                                            if (False if ((application_q_hat(adatum_reg)) is False) else True):
+                                                                                                            if (application_q_hat(adatum_reg) is not False):
                                                                                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_6_d, adatum_reg, senv_reg, info, handler_reg, k_reg)
                                                                                                                 GLOBALS['adatum_reg'] = car_hat(adatum_reg)
                                                                                                                 GLOBALS['pc'] = aparse
@@ -7136,17 +7193,17 @@ def aparse():
                                                                                                                 GLOBALS['pc'] = aparse_error
 
 def aparse_unit_tests():
-    if (False if ((null_q_hat(args_reg)) is False) else True):
+    if (null_q_hat(args_reg) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((symbol_q_hat(car_hat(args_reg))) is False) else True):
+        if (symbol_q_hat(car_hat(args_reg)) is not False):
             GLOBALS['k_reg'] = make_cont2(b_cont2_37_d, args_reg, k_reg)
             GLOBALS['args_reg'] = cdr_hat(args_reg)
             GLOBALS['pc'] = aparse_unit_tests
         else:
-            if (False if (((list_q_hat(car_hat(args_reg))) and (not(null_q_hat(car_hat(args_reg)))) and (symbol_q_hat(caar_hat(args_reg))) and (list_of_test_groups_q_hat(cdar_hat(args_reg)))) is False) else True):
+            if ((list_q_hat(car_hat(args_reg))) and (not(null_q_hat(car_hat(args_reg)))) and (symbol_q_hat(caar_hat(args_reg))) and (list_of_test_groups_q_hat(cdar_hat(args_reg))) is not False):
                 GLOBALS['k_reg'] = make_cont2(b_cont2_36_d, args_reg, k_reg)
                 GLOBALS['args_reg'] = cdr_hat(args_reg)
                 GLOBALS['pc'] = aparse_unit_tests
@@ -7156,7 +7213,7 @@ def aparse_unit_tests():
                 GLOBALS['pc'] = aparse_error
 
 def aparse_all():
-    if (False if ((null_q_hat(adatum_list_reg)) is False) else True):
+    if (null_q_hat(adatum_list_reg) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
@@ -7172,7 +7229,7 @@ def aparse_error():
     GLOBALS['pc'] = unannotate_cps
 
 def aparse_sexps():
-    if (False if ((token_type_q(first(tokens_reg), symbol_end_marker)) is False) else True):
+    if (token_type_q(first(tokens_reg), symbol_end_marker) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
@@ -7181,12 +7238,12 @@ def aparse_sexps():
         GLOBALS['pc'] = read_sexp
 
 def get_lexical_address():
-    if (False if ((((senv_reg) is symbol_emptylist)) is False) else True):
+    if (((senv_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = var_aexp(id_reg, info_reg)
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((memq(id_reg, (senv_reg).car)) is False) else True):
+        if (memq(id_reg, (senv_reg).car) is not False):
             GLOBALS['offset_reg'] = 0
             GLOBALS['contours_reg'] = (senv_reg).car
             GLOBALS['pc'] = get_lexical_address_offset
@@ -7196,7 +7253,7 @@ def get_lexical_address():
             GLOBALS['pc'] = get_lexical_address
 
 def get_lexical_address_offset():
-    if (False if ((((contours_reg).car) is (id_reg)) is False) else True):
+    if (((contours_reg).car) is (id_reg) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = lexical_address_aexp(depth_reg, offset_reg, id_reg, info_reg)
         GLOBALS['pc'] = apply_cont2
@@ -7206,25 +7263,25 @@ def get_lexical_address_offset():
         GLOBALS['pc'] = get_lexical_address_offset
 
 def get_internal_defines_hat(bodies, adatum, handler, fail, k):
-    if (False if ((null_q_hat(bodies)) is False) else True):
+    if (null_q_hat(bodies) is not False):
         GLOBALS['fail_reg'] = fail
         GLOBALS['handler_reg'] = handler
         GLOBALS['adatum_reg'] = adatum
         GLOBALS['msg_reg'] = "no body expressions found for"
         GLOBALS['pc'] = aparse_error
     else:
-        if (False if ((define_q_hat(car_hat(bodies))) is False) else True):
+        if (define_q_hat(car_hat(bodies)) is not False):
             return get_internal_defines_hat(cdr_hat(bodies), adatum, handler, fail, make_cont2(b_cont2_44_d, bodies, k))
         else:
             return any_internal_defines_q_hat(cdr_hat(bodies), make_cont(b_cont_25_d, adatum, bodies, handler, fail, k))
 
 def any_internal_defines_q_hat(exps, k):
-    if (False if ((null_q_hat(exps)) is False) else True):
+    if (null_q_hat(exps) is not False):
         GLOBALS['value_reg'] = False
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
     else:
-        if (False if ((define_q_hat(car_hat(exps))) is False) else True):
+        if (define_q_hat(car_hat(exps)) is not False):
             GLOBALS['value_reg'] = True
             GLOBALS['k_reg'] = k
             GLOBALS['pc'] = apply_cont
@@ -7232,7 +7289,7 @@ def any_internal_defines_q_hat(exps, k):
             return any_internal_defines_q_hat(cdr_hat(exps), k)
 
 def create_letrec_bindings_hat(defines, handler, fail, k):
-    if (False if ((((defines) is symbol_emptylist)) is False) else True):
+    if (((defines) is symbol_emptylist) is not False):
         GLOBALS['value_reg'] = symbol_emptylist
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont
@@ -7240,7 +7297,7 @@ def create_letrec_bindings_hat(defines, handler, fail, k):
         return create_letrec_bindings_hat((defines).cdr, handler, fail, make_cont(b_cont_26_d, defines, handler, fail, k))
 
 def get_define_var_and_exp_hat(adatum, handler, fail, k):
-    if (False if ((mit_style_define_q_hat(adatum)) is False) else True):
+    if (mit_style_define_q_hat(adatum) is not False):
         bodies = cddr_hat(adatum)
         formals = cdadr_hat(adatum)
         name = caadr_hat(adatum)
@@ -7249,7 +7306,7 @@ def get_define_var_and_exp_hat(adatum, handler, fail, k):
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((numeric_equal(length_hat(adatum), 3)) is False) else True):
+        if (numeric_equal(length_hat(adatum), 3) is not False):
             exp = caddr_hat(adatum)
             name = define_var_hat(adatum)
             GLOBALS['value2_reg'] = exp
@@ -7257,7 +7314,7 @@ def get_define_var_and_exp_hat(adatum, handler, fail, k):
             GLOBALS['k_reg'] = k
             GLOBALS['pc'] = apply_cont2
         else:
-            if (False if (((numeric_equal(length_hat(adatum), 4)) and (string_q_hat(caddr_hat(adatum)))) is False) else True):
+            if ((numeric_equal(length_hat(adatum), 4)) and (string_q_hat(caddr_hat(adatum))) is not False):
                 exp = cadddr_hat(adatum)
                 name = define_var_hat(adatum)
                 GLOBALS['value2_reg'] = exp
@@ -7272,7 +7329,7 @@ def get_define_var_and_exp_hat(adatum, handler, fail, k):
                 GLOBALS['pc'] = aparse_error
 
 def create_letrec_assignments_hat():
-    if (False if ((null_q_hat(vars_reg)) is False) else True):
+    if (null_q_hat(vars_reg) is not False):
         GLOBALS['value2_reg'] = symbol_emptylist
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['k_reg'] = k2_reg
@@ -7289,7 +7346,7 @@ def amacro_error():
     GLOBALS['pc'] = apply_handler2
 
 def nest_let_star_bindings_hat():
-    if (False if (((null_q_hat(bindings_reg)) or (null_q_hat(cdr_hat(bindings_reg)))) is False) else True):
+    if ((null_q_hat(bindings_reg)) or (null_q_hat(cdr_hat(bindings_reg))) is not False):
         GLOBALS['value_reg'] = append(List(symbol_let), append(List(bindings_reg), at_hat(bodies_reg)))
         GLOBALS['pc'] = apply_cont
     else:
@@ -7298,7 +7355,7 @@ def nest_let_star_bindings_hat():
         GLOBALS['pc'] = nest_let_star_bindings_hat
 
 def case_clauses_to_simple_cond_clauses_hat():
-    if (False if ((null_q_hat(clauses_reg)) is False) else True):
+    if (null_q_hat(clauses_reg) is not False):
         GLOBALS['value_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont
     else:
@@ -7307,7 +7364,7 @@ def case_clauses_to_simple_cond_clauses_hat():
         GLOBALS['pc'] = case_clauses_to_simple_cond_clauses_hat
 
 def case_clauses_to_cond_clauses_hat():
-    if (False if ((null_q_hat(clauses_reg)) is False) else True):
+    if (null_q_hat(clauses_reg) is not False):
         GLOBALS['value2_reg'] = symbol_emptylist
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['k_reg'] = k2_reg
@@ -7318,7 +7375,7 @@ def case_clauses_to_cond_clauses_hat():
         GLOBALS['pc'] = case_clauses_to_cond_clauses_hat
 
 def record_case_clauses_to_cond_clauses_hat():
-    if (False if ((null_q_hat(clauses_reg)) is False) else True):
+    if (null_q_hat(clauses_reg) is not False):
         GLOBALS['value2_reg'] = symbol_emptylist
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['k_reg'] = k2_reg
@@ -7329,7 +7386,7 @@ def record_case_clauses_to_cond_clauses_hat():
         GLOBALS['pc'] = record_case_clauses_to_cond_clauses_hat
 
 def make_dd_variant_constructors_hat():
-    if (False if ((null_q_hat(variants_reg)) is False) else True):
+    if (null_q_hat(variants_reg) is not False):
         GLOBALS['value2_reg'] = symbol_emptylist
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['k_reg'] = k2_reg
@@ -7349,7 +7406,7 @@ def make_dd_variant_constructor_hat():
     GLOBALS['pc'] = verify_dd_constructor_fields_hat
 
 def verify_dd_constructor_fields_hat():
-    if (False if ((null_q_hat(fields_reg)) is False) else True):
+    if (null_q_hat(fields_reg) is not False):
         GLOBALS['value_reg'] = append(List(symbol_cons), append(List(append(List(symbol_quote), List(name_reg))), List(symbol_args)))
         GLOBALS['pc'] = apply_cont
     else:
@@ -7388,7 +7445,7 @@ def list_of_define_syntax_clauses_q_hat(alist):
 def expand_once_hat():
     macro_keyword = untag_atom_hat(car_hat(adatum_reg))
     macro = get_first_frame_value(macro_keyword, macro_env)
-    if (False if ((pattern_macro_q(macro)) is False) else True):
+    if (pattern_macro_q(macro) is not False):
         GLOBALS['k_reg'] = make_cont2(b_cont2_55_d, macro_keyword, k_reg)
         GLOBALS['aclauses_reg'] = macro_aclauses(macro)
         GLOBALS['clauses_reg'] = macro_clauses(macro)
@@ -7400,7 +7457,7 @@ def expand_once_hat():
         GLOBALS['pc'] = apply_macro
 
 def process_macro_clauses_hat():
-    if (False if ((((clauses_reg) is symbol_emptylist)) is False) else True):
+    if (((clauses_reg) is symbol_emptylist) is not False):
         GLOBALS['msg_reg'] = "no matching clause found for"
         GLOBALS['pc'] = aparse_error
     else:
@@ -7413,37 +7470,37 @@ def process_macro_clauses_hat():
         GLOBALS['pc'] = unannotate_cps
 
 def qq_expand_cps():
-    if (False if ((quasiquote_q_hat(ax_reg)) is False) else True):
+    if (quasiquote_q_hat(ax_reg) is not False):
         GLOBALS['k_reg'] = make_cont(b_cont_39_d, k_reg)
         GLOBALS['depth_reg'] = (depth_reg) + (1)
         GLOBALS['ax_reg'] = cdr_hat(ax_reg)
         GLOBALS['pc'] = qq_expand_cps
     else:
-        if (False if (((unquote_q_hat(ax_reg)) or (unquote_splicing_q_hat(ax_reg))) is False) else True):
-            if (False if ((GreaterThan(depth_reg, 0)) is False) else True):
+        if ((unquote_q_hat(ax_reg)) or (unquote_splicing_q_hat(ax_reg)) is not False):
+            if (GreaterThan(depth_reg, 0) is not False):
                 GLOBALS['k_reg'] = make_cont(b_cont_40_d, ax_reg, k_reg)
                 GLOBALS['depth_reg'] = (depth_reg) - (1)
                 GLOBALS['ax_reg'] = cdr_hat(ax_reg)
                 GLOBALS['pc'] = qq_expand_cps
             else:
-                if (False if (((unquote_q_hat(ax_reg)) and (not(null_q_hat(cdr_hat(ax_reg)))) and (null_q_hat(cddr_hat(ax_reg)))) is False) else True):
+                if ((unquote_q_hat(ax_reg)) and (not(null_q_hat(cdr_hat(ax_reg)))) and (null_q_hat(cddr_hat(ax_reg))) is not False):
                     GLOBALS['value_reg'] = cadr_hat(ax_reg)
                     GLOBALS['pc'] = apply_cont
                 else:
                     GLOBALS['value_reg'] = append(List(symbol_quote), List(ax_reg))
                     GLOBALS['pc'] = apply_cont
         else:
-            if (False if ((vector_q_hat(ax_reg)) is False) else True):
+            if (vector_q_hat(ax_reg) is not False):
                 GLOBALS['k_reg'] = make_cont(b_cont_38_d, depth_reg, k_reg)
                 GLOBALS['info_reg'] = symbol_none
                 GLOBALS['x_reg'] = vector_to_list_hat(ax_reg)
                 GLOBALS['pc'] = annotate_cps
             else:
-                if (False if ((not(pair_q_hat(ax_reg))) is False) else True):
+                if (not(pair_q_hat(ax_reg)) is not False):
                     GLOBALS['value_reg'] = append(List(symbol_quote), List(ax_reg))
                     GLOBALS['pc'] = apply_cont
                 else:
-                    if (False if ((null_q_hat(cdr_hat(ax_reg))) is False) else True):
+                    if (null_q_hat(cdr_hat(ax_reg)) is not False):
                         GLOBALS['ax_reg'] = car_hat(ax_reg)
                         GLOBALS['pc'] = qq_expand_list_cps
                     else:
@@ -7452,39 +7509,39 @@ def qq_expand_cps():
                         GLOBALS['pc'] = qq_expand_list_cps
 
 def qq_expand_list_cps():
-    if (False if ((quasiquote_q_hat(ax_reg)) is False) else True):
+    if (quasiquote_q_hat(ax_reg) is not False):
         GLOBALS['k_reg'] = make_cont(b_cont_44_d, k_reg)
         GLOBALS['depth_reg'] = (depth_reg) + (1)
         GLOBALS['ax_reg'] = cdr_hat(ax_reg)
         GLOBALS['pc'] = qq_expand_cps
     else:
-        if (False if (((unquote_q_hat(ax_reg)) or (unquote_splicing_q_hat(ax_reg))) is False) else True):
-            if (False if ((GreaterThan(depth_reg, 0)) is False) else True):
+        if ((unquote_q_hat(ax_reg)) or (unquote_splicing_q_hat(ax_reg)) is not False):
+            if (GreaterThan(depth_reg, 0) is not False):
                 GLOBALS['k_reg'] = make_cont(b_cont_45_d, ax_reg, k_reg)
                 GLOBALS['depth_reg'] = (depth_reg) - (1)
                 GLOBALS['ax_reg'] = cdr_hat(ax_reg)
                 GLOBALS['pc'] = qq_expand_cps
             else:
-                if (False if ((unquote_q_hat(ax_reg)) is False) else True):
+                if (unquote_q_hat(ax_reg) is not False):
                     GLOBALS['value_reg'] = append(List(symbol_List), cdr_hat(ax_reg))
                     GLOBALS['pc'] = apply_cont
                 else:
-                    if (False if ((null_q_hat(cddr_hat(ax_reg))) is False) else True):
+                    if (null_q_hat(cddr_hat(ax_reg)) is not False):
                         GLOBALS['value_reg'] = cadr_hat(ax_reg)
                         GLOBALS['pc'] = apply_cont
                     else:
                         GLOBALS['value_reg'] = append(List(symbol_append), cdr_hat(ax_reg))
                         GLOBALS['pc'] = apply_cont
         else:
-            if (False if ((vector_q_hat(ax_reg)) is False) else True):
+            if (vector_q_hat(ax_reg) is not False):
                 GLOBALS['k_reg'] = make_cont(b_cont_41_d, k_reg)
                 GLOBALS['pc'] = qq_expand_cps
             else:
-                if (False if ((not(pair_q_hat(ax_reg))) is False) else True):
+                if (not(pair_q_hat(ax_reg)) is not False):
                     GLOBALS['value_reg'] = append(List(symbol_quote), List(List(ax_reg)))
                     GLOBALS['pc'] = apply_cont
                 else:
-                    if (False if ((null_q_hat(cdr_hat(ax_reg))) is False) else True):
+                    if (null_q_hat(cdr_hat(ax_reg)) is not False):
                         GLOBALS['k_reg'] = make_cont(b_cont_41_d, k_reg)
                         GLOBALS['ax_reg'] = car_hat(ax_reg)
                         GLOBALS['pc'] = qq_expand_list_cps
@@ -7494,113 +7551,113 @@ def qq_expand_list_cps():
                         GLOBALS['pc'] = qq_expand_list_cps
 
 def aunparse(aexp):
-    if (False if ((((aexp).car) is (symbol_lit_aexp)) is False) else True):
-        datum = list_ref(aexp, 1)
-        if (False if ((((datum) is symbol_emptylist)) is False) else True):
+    if (((aexp).car) is (symbol_lit_aexp) is not False):
+        datum = ((aexp)).cdr.car
+        if (((datum) is symbol_emptylist) is not False):
             return List(symbol_quote, symbol_emptylist)
         else:
-            if (False if ((literal_q(datum)) is False) else True):
+            if (literal_q(datum) is not False):
                 return datum
             else:
-                if (False if ((vector_q(datum)) is False) else True):
+                if (vector_q(datum) is not False):
                     return datum
                 else:
                     return append(List(symbol_quote), List(datum))
     else:
-        if (False if ((((aexp).car) is (symbol_var_aexp)) is False) else True):
-            id = list_ref(aexp, 1)
+        if (((aexp).car) is (symbol_var_aexp) is not False):
+            id = ((aexp)).cdr.car
             return id
         else:
-            if (False if ((((aexp).car) is (symbol_lexical_address_aexp)) is False) else True):
-                id = list_ref(aexp, 3)
+            if (((aexp).car) is (symbol_lexical_address_aexp) is not False):
+                id = ((((aexp)).cdr).cdr).cdr.car
                 return id
             else:
-                if (False if ((((aexp).car) is (symbol_if_aexp)) is False) else True):
-                    else_aexp = list_ref(aexp, 3)
-                    then_aexp = list_ref(aexp, 2)
-                    test_aexp = list_ref(aexp, 1)
+                if (((aexp).car) is (symbol_if_aexp) is not False):
+                    else_aexp = ((((aexp)).cdr).cdr).cdr.car
+                    then_aexp = (((aexp)).cdr).cdr.car
+                    test_aexp = ((aexp)).cdr.car
                     return append(List(symbol_if), append(List(aunparse(test_aexp)), append(List(aunparse(then_aexp)), List(aunparse(else_aexp)))))
                 else:
-                    if (False if ((((aexp).car) is (symbol_assign_aexp)) is False) else True):
-                        rhs_exp = list_ref(aexp, 2)
-                        var = list_ref(aexp, 1)
+                    if (((aexp).car) is (symbol_assign_aexp) is not False):
+                        rhs_exp = (((aexp)).cdr).cdr.car
+                        var = ((aexp)).cdr.car
                         return append(List(symbol_set_b), append(List(var), List(aunparse(rhs_exp))))
                     else:
-                        if (False if ((((aexp).car) is (symbol_func_aexp)) is False) else True):
-                            exp = list_ref(aexp, 1)
+                        if (((aexp).car) is (symbol_func_aexp) is not False):
+                            exp = ((aexp)).cdr.car
                             return append(List(symbol_func), List(aunparse(exp)))
                         else:
-                            if (False if ((((aexp).car) is (symbol_callback_aexp)) is False) else True):
-                                exp = list_ref(aexp, 1)
+                            if (((aexp).car) is (symbol_callback_aexp) is not False):
+                                exp = ((aexp)).cdr.car
                                 return append(List(symbol_callback), List(aunparse(exp)))
                             else:
-                                if (False if ((((aexp).car) is (symbol_define_aexp)) is False) else True):
-                                    rhs_exp = list_ref(aexp, 3)
-                                    docstring = list_ref(aexp, 2)
-                                    id = list_ref(aexp, 1)
-                                    if (False if ((string_is__q(docstring, "")) is False) else True):
+                                if (((aexp).car) is (symbol_define_aexp) is not False):
+                                    rhs_exp = ((((aexp)).cdr).cdr).cdr.car
+                                    docstring = (((aexp)).cdr).cdr.car
+                                    id = ((aexp)).cdr.car
+                                    if (string_is__q(docstring, "") is not False):
                                         return append(List(symbol_define), append(List(id), List(aunparse(rhs_exp))))
                                     else:
                                         return append(List(symbol_define), append(List(id), append(List(docstring), List(aunparse(rhs_exp)))))
                                 else:
-                                    if (False if ((((aexp).car) is (symbol_define_b_aexp)) is False) else True):
-                                        rhs_exp = list_ref(aexp, 3)
-                                        docstring = list_ref(aexp, 2)
-                                        id = list_ref(aexp, 1)
-                                        if (False if ((string_is__q(docstring, "")) is False) else True):
+                                    if (((aexp).car) is (symbol_define_b_aexp) is not False):
+                                        rhs_exp = ((((aexp)).cdr).cdr).cdr.car
+                                        docstring = (((aexp)).cdr).cdr.car
+                                        id = ((aexp)).cdr.car
+                                        if (string_is__q(docstring, "") is not False):
                                             return append(List(symbol_define_b), append(List(id), List(aunparse(rhs_exp))))
                                         else:
                                             return append(List(symbol_define_b), append(List(id), append(List(docstring), List(aunparse(rhs_exp)))))
                                     else:
-                                        if (False if ((((aexp).car) is (symbol_define_syntax_aexp)) is False) else True):
-                                            clauses = list_ref(aexp, 2)
-                                            name = list_ref(aexp, 1)
+                                        if (((aexp).car) is (symbol_define_syntax_aexp) is not False):
+                                            clauses = (((aexp)).cdr).cdr.car
+                                            name = ((aexp)).cdr.car
                                             return append(List(symbol_define_syntax), append(List(name), clauses))
                                         else:
-                                            if (False if ((((aexp).car) is (symbol_begin_aexp)) is False) else True):
-                                                exps = list_ref(aexp, 1)
+                                            if (((aexp).car) is (symbol_begin_aexp) is not False):
+                                                exps = ((aexp)).cdr.car
                                                 return append(List(symbol_begin), Map(aunparse, exps))
                                             else:
-                                                if (False if ((((aexp).car) is (symbol_lambda_aexp)) is False) else True):
-                                                    bodies = list_ref(aexp, 2)
-                                                    formals = list_ref(aexp, 1)
+                                                if (((aexp).car) is (symbol_lambda_aexp) is not False):
+                                                    bodies = (((aexp)).cdr).cdr.car
+                                                    formals = ((aexp)).cdr.car
                                                     return append(List(symbol_lambda), append(List(formals), Map(aunparse, bodies)))
                                                 else:
-                                                    if (False if ((((aexp).car) is (symbol_mu_lambda_aexp)) is False) else True):
-                                                        bodies = list_ref(aexp, 3)
-                                                        runt = list_ref(aexp, 2)
-                                                        formals = list_ref(aexp, 1)
+                                                    if (((aexp).car) is (symbol_mu_lambda_aexp) is not False):
+                                                        bodies = ((((aexp)).cdr).cdr).cdr.car
+                                                        runt = (((aexp)).cdr).cdr.car
+                                                        formals = ((aexp)).cdr.car
                                                         return append(List(symbol_lambda), append(List(append(formals, runt)), Map(aunparse, bodies)))
                                                     else:
-                                                        if (False if ((((aexp).car) is (symbol_app_aexp)) is False) else True):
-                                                            operands = list_ref(aexp, 2)
-                                                            operator = list_ref(aexp, 1)
+                                                        if (((aexp).car) is (symbol_app_aexp) is not False):
+                                                            operands = (((aexp)).cdr).cdr.car
+                                                            operator = ((aexp)).cdr.car
                                                             return append(List(aunparse(operator)), Map(aunparse, operands))
                                                         else:
-                                                            if (False if ((((aexp).car) is (symbol_try_catch_aexp)) is False) else True):
-                                                                catch_exps = list_ref(aexp, 3)
-                                                                catch_var = list_ref(aexp, 2)
-                                                                body = list_ref(aexp, 1)
+                                                            if (((aexp).car) is (symbol_try_catch_aexp) is not False):
+                                                                catch_exps = ((((aexp)).cdr).cdr).cdr.car
+                                                                catch_var = (((aexp)).cdr).cdr.car
+                                                                body = ((aexp)).cdr.car
                                                                 return append(List(symbol_try), append(List(aunparse(body)), List(append(List(symbol_catch), append(List(catch_var), Map(aunparse, catch_exps))))))
                                                             else:
-                                                                if (False if ((((aexp).car) is (symbol_try_finally_aexp)) is False) else True):
-                                                                    finally_exps = list_ref(aexp, 2)
-                                                                    body = list_ref(aexp, 1)
+                                                                if (((aexp).car) is (symbol_try_finally_aexp) is not False):
+                                                                    finally_exps = (((aexp)).cdr).cdr.car
+                                                                    body = ((aexp)).cdr.car
                                                                     return append(List(symbol_try), append(List(aunparse(body)), List(append(List(symbol_finally), Map(aunparse, finally_exps)))))
                                                                 else:
-                                                                    if (False if ((((aexp).car) is (symbol_try_catch_finally_aexp)) is False) else True):
-                                                                        finally_exps = list_ref(aexp, 4)
-                                                                        catch_exps = list_ref(aexp, 3)
-                                                                        catch_var = list_ref(aexp, 2)
-                                                                        body = list_ref(aexp, 1)
+                                                                    if (((aexp).car) is (symbol_try_catch_finally_aexp) is not False):
+                                                                        finally_exps = (((((aexp)).cdr).cdr).cdr).cdr.car
+                                                                        catch_exps = ((((aexp)).cdr).cdr).cdr.car
+                                                                        catch_var = (((aexp)).cdr).cdr.car
+                                                                        body = ((aexp)).cdr.car
                                                                         return append(List(symbol_try), append(List(aunparse(body)), append(List(append(List(symbol_catch), append(List(catch_var), Map(aunparse, catch_exps)))), List(append(List(symbol_finally), Map(aunparse, finally_exps))))))
                                                                     else:
-                                                                        if (False if ((((aexp).car) is (symbol_raise_aexp)) is False) else True):
-                                                                            exp = list_ref(aexp, 1)
+                                                                        if (((aexp).car) is (symbol_raise_aexp) is not False):
+                                                                            exp = ((aexp)).cdr.car
                                                                             return append(List(symbol_raise), List(aunparse(exp)))
                                                                         else:
-                                                                            if (False if ((((aexp).car) is (symbol_choose_aexp)) is False) else True):
-                                                                                exps = list_ref(aexp, 1)
+                                                                            if (((aexp).car) is (symbol_choose_aexp) is not False):
+                                                                                exps = ((aexp)).cdr.car
                                                                                 return append(List(symbol_choose), Map(aunparse, exps))
                                                                             else:
                                                                                 raise Exception("symbol_aunparse: " + format("bad abstract syntax: ~s", *[aexp]))
@@ -7612,14 +7669,14 @@ def make_test_callback(group_name, case_name, result, traceback, proc_exp, test_
     return void_value
 
 def path_join(path, filename):
-    if (False if ((((path) is symbol_emptylist)) is False) else True):
+    if (((path) is symbol_emptylist) is not False):
         return filename
     else:
         return path_join((path).cdr, string_append((path).car, "/", filename))
 
 def use_lexical_address(*args):
     args = List(*args)
-    if (False if ((((args) is symbol_emptylist)) is False) else True):
+    if (((args) is symbol_emptylist) is not False):
         return _staruse_lexical_address_star
     else:
         GLOBALS['_staruse_lexical_address_star'] = true_q((args).car)
@@ -7630,19 +7687,19 @@ def handle_exception(exc):
     return void_value
 
 def get_traceback_string(exc):
-    if (False if (((list_q((exc).cdr.car)) and (numeric_equal(length((exc).cdr.car), 7))) is False) else True):
+    if ((list_q((exc).cdr.car)) and (numeric_equal(length((exc).cdr.car), 7)) is not False):
         retval = ""
-        stack = list_ref((exc).cdr.car, 6)
-        src_col = list_ref((exc).cdr.car, 5)
-        src_line = list_ref((exc).cdr.car, 4)
-        src_file = list_ref((exc).cdr.car, 3)
-        message = list_ref((exc).cdr.car, 2)
-        error_type = list_ref((exc).cdr.car, 1)
+        stack = ((((((((exc).cdr.car)).cdr).cdr).cdr).cdr).cdr).cdr.car
+        src_col = (((((((exc).cdr.car)).cdr).cdr).cdr).cdr).cdr.car
+        src_line = ((((((exc).cdr.car)).cdr).cdr).cdr).cdr.car
+        src_file = (((((exc).cdr.car)).cdr).cdr).cdr.car
+        message = ((((exc).cdr.car)).cdr).cdr.car
+        error_type = (((exc).cdr.car)).cdr.car
         retval = string_append(retval, format("~%Traceback (most recent call last):~%"))
         while not(((stack) is symbol_emptylist)):
             retval = string_append(retval, format_exception_line((stack).car))
             stack = (stack).cdr
-        if (False if ((not((src_file) is (symbol_none))) is False) else True):
+        if (not((src_file) is (symbol_none)) is not False):
             retval = string_append(retval, format("  File \"~a\", line ~a, col ~a~%", src_file, src_line, src_col))
         return string_append(retval, format("~a: ~a~%", error_type, message))
     else:
@@ -7650,19 +7707,19 @@ def get_traceback_string(exc):
         return string_append(retval, format("Raised Exception: ~a~%", (exc).cdr.car))
 
 def get_exception_values(exc):
-    if (False if (((list_q((exc).cdr.car)) and (GreaterThan(length((exc).cdr.car), 2))) is False) else True):
-        message = list_ref((exc).cdr.car, 2)
-        error_type = list_ref((exc).cdr.car, 1)
+    if ((list_q((exc).cdr.car)) and (GreaterThan(length((exc).cdr.car), 2)) is not False):
+        message = ((((exc).cdr.car)).cdr).cdr.car
+        error_type = (((exc).cdr.car)).cdr.car
         return list_to_vector(List(error_type, message))
     else:
         return list_to_vector(List("UnhandledException", (exc).cdr.car))
 
 def format_exception_line(line):
-    if (False if ((list_q(line)) is False) else True):
+    if (list_q(line) is not False):
         column_number = (line).cdr.cdr.car
         line_number = (line).cdr.car
         filename = (line).car
-        if (False if ((numeric_equal(length(line), 3)) is False) else True):
+        if (numeric_equal(length(line), 3) is not False):
             return format("  File \"~a\", line ~a, col ~a~%", filename, line_number, column_number)
         else:
             return format("  File \"~a\", line ~a, col ~a, in '~a'~%", filename, line_number, column_number, (line).cdr.cdr.cdr.car)
@@ -7673,11 +7730,11 @@ def read_eval_print_loop_rm():
     input_ = read_multiline("==> ")
     result = execute_rm(input_, "stdin")
     while not(end_of_session_q(result)):
-        if (False if ((exception_q(result)) is False) else True):
+        if (exception_q(result) is not False):
             handle_exception(result)
         else:
-            if (False if ((not(void_q(result))) is False) else True):
-                if (False if ((_starneed_newline_star) is False) else True):
+            if (not(void_q(result)) is not False):
+                if (_starneed_newline_star is not False):
                     newline()
                 safe_print(result)
         input_ = read_multiline("==> ")
@@ -7703,11 +7760,11 @@ def execute_rm(input_, src):
     GLOBALS['input_reg'] = input_
     GLOBALS['pc'] = scan_input
     result = trampoline()
-    if (False if ((exception_q(result)) is False) else True):
+    if (exception_q(result) is not False):
         return result
     else:
         GLOBALS['_startokens_left_star'] = result
-        if (False if ((token_type_q(first(_startokens_left_star), symbol_end_marker)) is False) else True):
+        if (token_type_q(first(_startokens_left_star), symbol_end_marker) is not False):
             return void_value
         else:
             return execute_loop_rm(src)
@@ -7715,7 +7772,7 @@ def execute_rm(input_, src):
 def execute_loop_rm(src):
     execute_next_expression_rm(src)
     result = trampoline()
-    if (False if (((exception_q(result)) or (end_of_session_q(result)) or (token_type_q(first(_startokens_left_star), symbol_end_marker))) is False) else True):
+    if ((exception_q(result)) or (end_of_session_q(result)) or (token_type_q(first(_startokens_left_star), symbol_end_marker)) is not False):
         return result
     else:
         return execute_loop_rm(src)
@@ -7773,60 +7830,60 @@ def push_stack_trace_b(exp):
     set_car_b(_starstack_trace_star, cons(exp, (_starstack_trace_star).car))
 
 def pop_stack_trace_b(exp):
-    if (False if ((not((((_starstack_trace_star).car) is symbol_emptylist))) is False) else True):
+    if (not((((_starstack_trace_star).car) is symbol_emptylist)) is not False):
         set_car_b(_starstack_trace_star, ((_starstack_trace_star).car).cdr)
 
 def m():
-    if (False if ((_startracing_on_q_star) is False) else True):
+    if (_startracing_on_q_star is not False):
         highlight_expression(exp_reg)
     k = (make_debugging_k(exp_reg, k_reg) if _startracing_on_q_star else k_reg)
-    if (False if ((((exp_reg).car) is (symbol_lit_aexp)) is False) else True):
-        datum = list_ref(exp_reg, 1)
+    if (((exp_reg).car) is (symbol_lit_aexp) is not False):
+        datum = ((exp_reg)).cdr.car
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = datum
         GLOBALS['k_reg'] = k
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((((exp_reg).car) is (symbol_var_aexp)) is False) else True):
-            info = list_ref(exp_reg, 2)
-            id = list_ref(exp_reg, 1)
+        if (((exp_reg).car) is (symbol_var_aexp) is not False):
+            info = (((exp_reg)).cdr).cdr.car
+            id = ((exp_reg)).cdr.car
             GLOBALS['k_reg'] = k
             GLOBALS['var_info_reg'] = info
             GLOBALS['var_reg'] = id
             GLOBALS['pc'] = lookup_value
         else:
-            if (False if ((((exp_reg).car) is (symbol_lexical_address_aexp)) is False) else True):
-                offset = list_ref(exp_reg, 2)
-                depth = list_ref(exp_reg, 1)
+            if (((exp_reg).car) is (symbol_lexical_address_aexp) is not False):
+                offset = (((exp_reg)).cdr).cdr.car
+                depth = ((exp_reg)).cdr.car
                 GLOBALS['k_reg'] = k
                 GLOBALS['frames_reg'] = frames(env_reg)
                 GLOBALS['offset_reg'] = offset
                 GLOBALS['depth_reg'] = depth
                 GLOBALS['pc'] = lookup_value_by_lexical_address
             else:
-                if (False if ((((exp_reg).car) is (symbol_func_aexp)) is False) else True):
-                    exp = list_ref(exp_reg, 1)
+                if (((exp_reg).car) is (symbol_func_aexp) is not False):
+                    exp = ((exp_reg)).cdr.car
                     GLOBALS['k_reg'] = make_cont2(b_cont2_83_d, k)
                     GLOBALS['exp_reg'] = exp
                     GLOBALS['pc'] = m
                 else:
-                    if (False if ((((exp_reg).car) is (symbol_callback_aexp)) is False) else True):
-                        exp = list_ref(exp_reg, 1)
+                    if (((exp_reg).car) is (symbol_callback_aexp) is not False):
+                        exp = ((exp_reg)).cdr.car
                         GLOBALS['k_reg'] = make_cont2(b_cont2_81_d, k)
                         GLOBALS['exp_reg'] = exp
                         GLOBALS['pc'] = m
                     else:
-                        if (False if ((((exp_reg).car) is (symbol_if_aexp)) is False) else True):
-                            else_exp = list_ref(exp_reg, 3)
-                            then_exp = list_ref(exp_reg, 2)
-                            test_exp = list_ref(exp_reg, 1)
+                        if (((exp_reg).car) is (symbol_if_aexp) is not False):
+                            else_exp = ((((exp_reg)).cdr).cdr).cdr.car
+                            then_exp = (((exp_reg)).cdr).cdr.car
+                            test_exp = ((exp_reg)).cdr.car
                             GLOBALS['k_reg'] = make_cont2(b_cont2_82_d, else_exp, then_exp, env_reg, handler_reg, k)
                             GLOBALS['exp_reg'] = test_exp
                             GLOBALS['pc'] = m
                         else:
-                            if (False if ((((exp_reg).car) is (symbol_help_aexp)) is False) else True):
-                                var_info = list_ref(exp_reg, 2)
-                                var = list_ref(exp_reg, 1)
+                            if (((exp_reg).car) is (symbol_help_aexp) is not False):
+                                var_info = (((exp_reg)).cdr).cdr.car
+                                var = ((exp_reg)).cdr.car
                                 GLOBALS['sk_reg'] = make_cont2(b_cont2_78_d, k)
                                 GLOBALS['dk_reg'] = make_cont3(b_cont3_5_d, k)
                                 GLOBALS['gk_reg'] = make_cont2(b_cont2_79_d, k)
@@ -7834,59 +7891,59 @@ def m():
                                 GLOBALS['var_reg'] = var
                                 GLOBALS['pc'] = lookup_variable
                             else:
-                                if (False if ((((exp_reg).car) is (symbol_association_aexp)) is False) else True):
-                                    exp = list_ref(exp_reg, 2)
-                                    var = list_ref(exp_reg, 1)
+                                if (((exp_reg).car) is (symbol_association_aexp) is not False):
+                                    exp = (((exp_reg)).cdr).cdr.car
+                                    var = ((exp_reg)).cdr.car
                                     GLOBALS['k_reg'] = make_cont2(b_cont2_80_d, var, k)
                                     GLOBALS['exp_reg'] = exp
                                     GLOBALS['pc'] = m
                                 else:
-                                    if (False if ((((exp_reg).car) is (symbol_assign_aexp)) is False) else True):
-                                        var_info = list_ref(exp_reg, 3)
-                                        rhs_exp = list_ref(exp_reg, 2)
-                                        var = list_ref(exp_reg, 1)
+                                    if (((exp_reg).car) is (symbol_assign_aexp) is not False):
+                                        var_info = ((((exp_reg)).cdr).cdr).cdr.car
+                                        rhs_exp = (((exp_reg)).cdr).cdr.car
+                                        var = ((exp_reg)).cdr.car
                                         GLOBALS['k_reg'] = make_cont2(b_cont2_75_d, var, var_info, env_reg, handler_reg, k)
                                         GLOBALS['exp_reg'] = rhs_exp
                                         GLOBALS['pc'] = m
                                     else:
-                                        if (False if ((((exp_reg).car) is (symbol_define_aexp)) is False) else True):
-                                            rhs_exp = list_ref(exp_reg, 3)
-                                            docstring = list_ref(exp_reg, 2)
-                                            var = list_ref(exp_reg, 1)
+                                        if (((exp_reg).car) is (symbol_define_aexp) is not False):
+                                            rhs_exp = ((((exp_reg)).cdr).cdr).cdr.car
+                                            docstring = (((exp_reg)).cdr).cdr.car
+                                            var = ((exp_reg)).cdr.car
                                             GLOBALS['k_reg'] = make_cont2(b_cont2_77_d, docstring, var, env_reg, handler_reg, k)
                                             GLOBALS['exp_reg'] = rhs_exp
                                             GLOBALS['pc'] = m
                                         else:
-                                            if (False if ((((exp_reg).car) is (symbol_define_b_aexp)) is False) else True):
-                                                rhs_exp = list_ref(exp_reg, 3)
-                                                docstring = list_ref(exp_reg, 2)
-                                                var = list_ref(exp_reg, 1)
+                                            if (((exp_reg).car) is (symbol_define_b_aexp) is not False):
+                                                rhs_exp = ((((exp_reg)).cdr).cdr).cdr.car
+                                                docstring = (((exp_reg)).cdr).cdr.car
+                                                var = ((exp_reg)).cdr.car
                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_71_d, docstring, var, k)
                                                 GLOBALS['exp_reg'] = rhs_exp
                                                 GLOBALS['pc'] = m
                                             else:
-                                                if (False if ((((exp_reg).car) is (symbol_define_syntax_aexp)) is False) else True):
-                                                    aclauses = list_ref(exp_reg, 3)
-                                                    clauses = list_ref(exp_reg, 2)
-                                                    name = list_ref(exp_reg, 1)
+                                                if (((exp_reg).car) is (symbol_define_syntax_aexp) is not False):
+                                                    aclauses = ((((exp_reg)).cdr).cdr).cdr.car
+                                                    clauses = (((exp_reg)).cdr).cdr.car
+                                                    name = ((exp_reg)).cdr.car
                                                     GLOBALS['k_reg'] = make_cont2(b_cont2_72_d, aclauses, clauses, k)
                                                     GLOBALS['env_reg'] = macro_env
                                                     GLOBALS['var_reg'] = name
                                                     GLOBALS['pc'] = lookup_binding_in_first_frame
                                                 else:
-                                                    if (False if ((((exp_reg).car) is (symbol_define_syntax_transformer_aexp)) is False) else True):
-                                                        info = list_ref(exp_reg, 3)
-                                                        rhs_exp = list_ref(exp_reg, 2)
-                                                        name = list_ref(exp_reg, 1)
+                                                    if (((exp_reg).car) is (symbol_define_syntax_transformer_aexp) is not False):
+                                                        info = ((((exp_reg)).cdr).cdr).cdr.car
+                                                        rhs_exp = (((exp_reg)).cdr).cdr.car
+                                                        name = ((exp_reg)).cdr.car
                                                         GLOBALS['k_reg'] = make_cont2(b_cont2_70_d, name, env_reg, info, handler_reg, k)
                                                         GLOBALS['exp_reg'] = rhs_exp
                                                         GLOBALS['pc'] = m
                                                     else:
-                                                        if (False if ((((exp_reg).car) is (symbol_define_tests_aexp)) is False) else True):
-                                                            info = list_ref(exp_reg, 3)
-                                                            aclauses = list_ref(exp_reg, 2)
-                                                            name = list_ref(exp_reg, 1)
-                                                            if (False if ((hasitem_native(unit_test_table, name)) is False) else True):
+                                                        if (((exp_reg).car) is (symbol_define_tests_aexp) is not False):
+                                                            info = ((((exp_reg)).cdr).cdr).cdr.car
+                                                            aclauses = (((exp_reg)).cdr).cdr.car
+                                                            name = ((exp_reg)).cdr.car
+                                                            if (hasitem_native(unit_test_table, name) is not False):
                                                                 GLOBALS['info_reg'] = info
                                                                 GLOBALS['msg_reg'] = format("duplicate unit test group name '~a'; did you forget to (clear-unit-tests)?", name)
                                                                 GLOBALS['pc'] = runtime_error
@@ -7897,9 +7954,9 @@ def m():
                                                                 GLOBALS['k_reg'] = k
                                                                 GLOBALS['pc'] = apply_cont2
                                                         else:
-                                                            if (False if ((((exp_reg).car) is (symbol_run_tests_aexp)) is False) else True):
-                                                                tests = list_ref(exp_reg, 1)
-                                                                if (False if ((((tests) is symbol_emptylist)) is False) else True):
+                                                            if (((exp_reg).car) is (symbol_run_tests_aexp) is not False):
+                                                                tests = ((exp_reg)).cdr.car
+                                                                if (((tests) is symbol_emptylist) is not False):
                                                                     GLOBALS['k_reg'] = k
                                                                     GLOBALS['wrong_reg'] = 0
                                                                     GLOBALS['right_reg'] = 0
@@ -7914,95 +7971,95 @@ def m():
                                                                     GLOBALS['tests_reg'] = tests
                                                                     GLOBALS['pc'] = run_unit_tests
                                                             else:
-                                                                if (False if ((((exp_reg).car) is (symbol_begin_aexp)) is False) else True):
-                                                                    exps = list_ref(exp_reg, 1)
+                                                                if (((exp_reg).car) is (symbol_begin_aexp) is not False):
+                                                                    exps = ((exp_reg)).cdr.car
                                                                     GLOBALS['k_reg'] = k
                                                                     GLOBALS['exps_reg'] = exps
                                                                     GLOBALS['pc'] = eval_sequence
                                                                 else:
-                                                                    if (False if ((((exp_reg).car) is (symbol_lambda_aexp)) is False) else True):
-                                                                        bodies = list_ref(exp_reg, 2)
-                                                                        formals = list_ref(exp_reg, 1)
+                                                                    if (((exp_reg).car) is (symbol_lambda_aexp) is not False):
+                                                                        bodies = (((exp_reg)).cdr).cdr.car
+                                                                        formals = ((exp_reg)).cdr.car
                                                                         GLOBALS['value2_reg'] = fail_reg
                                                                         GLOBALS['value1_reg'] = closure(formals, bodies, env_reg)
                                                                         GLOBALS['k_reg'] = k
                                                                         GLOBALS['pc'] = apply_cont2
                                                                     else:
-                                                                        if (False if ((((exp_reg).car) is (symbol_mu_lambda_aexp)) is False) else True):
-                                                                            bodies = list_ref(exp_reg, 3)
-                                                                            runt = list_ref(exp_reg, 2)
-                                                                            formals = list_ref(exp_reg, 1)
+                                                                        if (((exp_reg).car) is (symbol_mu_lambda_aexp) is not False):
+                                                                            bodies = ((((exp_reg)).cdr).cdr).cdr.car
+                                                                            runt = (((exp_reg)).cdr).cdr.car
+                                                                            formals = ((exp_reg)).cdr.car
                                                                             GLOBALS['value2_reg'] = fail_reg
                                                                             GLOBALS['value1_reg'] = mu_closure(formals, get_symbol(runt), bodies, env_reg)
                                                                             GLOBALS['k_reg'] = k
                                                                             GLOBALS['pc'] = apply_cont2
                                                                         else:
-                                                                            if (False if ((((exp_reg).car) is (symbol_trace_lambda_aexp)) is False) else True):
-                                                                                bodies = list_ref(exp_reg, 3)
-                                                                                formals = list_ref(exp_reg, 2)
-                                                                                name = list_ref(exp_reg, 1)
+                                                                            if (((exp_reg).car) is (symbol_trace_lambda_aexp) is not False):
+                                                                                bodies = ((((exp_reg)).cdr).cdr).cdr.car
+                                                                                formals = (((exp_reg)).cdr).cdr.car
+                                                                                name = ((exp_reg)).cdr.car
                                                                                 GLOBALS['value2_reg'] = fail_reg
                                                                                 GLOBALS['value1_reg'] = trace_closure(name, formals, bodies, env_reg)
                                                                                 GLOBALS['k_reg'] = k
                                                                                 GLOBALS['pc'] = apply_cont2
                                                                             else:
-                                                                                if (False if ((((exp_reg).car) is (symbol_mu_trace_lambda_aexp)) is False) else True):
-                                                                                    bodies = list_ref(exp_reg, 4)
-                                                                                    runt = list_ref(exp_reg, 3)
-                                                                                    formals = list_ref(exp_reg, 2)
-                                                                                    name = list_ref(exp_reg, 1)
+                                                                                if (((exp_reg).car) is (symbol_mu_trace_lambda_aexp) is not False):
+                                                                                    bodies = (((((exp_reg)).cdr).cdr).cdr).cdr.car
+                                                                                    runt = ((((exp_reg)).cdr).cdr).cdr.car
+                                                                                    formals = (((exp_reg)).cdr).cdr.car
+                                                                                    name = ((exp_reg)).cdr.car
                                                                                     GLOBALS['value2_reg'] = fail_reg
                                                                                     GLOBALS['value1_reg'] = mu_trace_closure(name, formals, get_symbol(runt), bodies, env_reg)
                                                                                     GLOBALS['k_reg'] = k
                                                                                     GLOBALS['pc'] = apply_cont2
                                                                                 else:
-                                                                                    if (False if ((((exp_reg).car) is (symbol_try_catch_aexp)) is False) else True):
-                                                                                        cexps = list_ref(exp_reg, 3)
-                                                                                        cvar = list_ref(exp_reg, 2)
-                                                                                        body = list_ref(exp_reg, 1)
+                                                                                    if (((exp_reg).car) is (symbol_try_catch_aexp) is not False):
+                                                                                        cexps = ((((exp_reg)).cdr).cdr).cdr.car
+                                                                                        cvar = (((exp_reg)).cdr).cdr.car
+                                                                                        body = ((exp_reg)).cdr.car
                                                                                         new_handler = try_catch_handler(cvar, cexps, env_reg, handler_reg, k)
                                                                                         GLOBALS['k_reg'] = k
                                                                                         GLOBALS['handler_reg'] = new_handler
                                                                                         GLOBALS['exp_reg'] = body
                                                                                         GLOBALS['pc'] = m
                                                                                     else:
-                                                                                        if (False if ((((exp_reg).car) is (symbol_try_finally_aexp)) is False) else True):
-                                                                                            fexps = list_ref(exp_reg, 2)
-                                                                                            body = list_ref(exp_reg, 1)
+                                                                                        if (((exp_reg).car) is (symbol_try_finally_aexp) is not False):
+                                                                                            fexps = (((exp_reg)).cdr).cdr.car
+                                                                                            body = ((exp_reg)).cdr.car
                                                                                             new_handler = try_finally_handler(fexps, env_reg, handler_reg)
                                                                                             GLOBALS['k_reg'] = make_cont2(b_cont2_66_d, fexps, env_reg, handler_reg, k)
                                                                                             GLOBALS['handler_reg'] = new_handler
                                                                                             GLOBALS['exp_reg'] = body
                                                                                             GLOBALS['pc'] = m
                                                                                         else:
-                                                                                            if (False if ((((exp_reg).car) is (symbol_try_catch_finally_aexp)) is False) else True):
-                                                                                                fexps = list_ref(exp_reg, 4)
-                                                                                                cexps = list_ref(exp_reg, 3)
-                                                                                                cvar = list_ref(exp_reg, 2)
-                                                                                                body = list_ref(exp_reg, 1)
+                                                                                            if (((exp_reg).car) is (symbol_try_catch_finally_aexp) is not False):
+                                                                                                fexps = (((((exp_reg)).cdr).cdr).cdr).cdr.car
+                                                                                                cexps = ((((exp_reg)).cdr).cdr).cdr.car
+                                                                                                cvar = (((exp_reg)).cdr).cdr.car
+                                                                                                body = ((exp_reg)).cdr.car
                                                                                                 new_handler = try_catch_finally_handler(cvar, cexps, fexps, env_reg, handler_reg, k)
                                                                                                 GLOBALS['k_reg'] = make_cont2(b_cont2_66_d, fexps, env_reg, handler_reg, k)
                                                                                                 GLOBALS['handler_reg'] = new_handler
                                                                                                 GLOBALS['exp_reg'] = body
                                                                                                 GLOBALS['pc'] = m
                                                                                             else:
-                                                                                                if (False if ((((exp_reg).car) is (symbol_raise_aexp)) is False) else True):
-                                                                                                    info = list_ref(exp_reg, 2)
-                                                                                                    exp = list_ref(exp_reg, 1)
+                                                                                                if (((exp_reg).car) is (symbol_raise_aexp) is not False):
+                                                                                                    info = (((exp_reg)).cdr).cdr.car
+                                                                                                    exp = ((exp_reg)).cdr.car
                                                                                                     GLOBALS['k_reg'] = make_cont2(b_cont2_67_d, info, handler_reg)
                                                                                                     GLOBALS['exp_reg'] = exp
                                                                                                     GLOBALS['pc'] = m
                                                                                                 else:
-                                                                                                    if (False if ((((exp_reg).car) is (symbol_choose_aexp)) is False) else True):
-                                                                                                        exps = list_ref(exp_reg, 1)
+                                                                                                    if (((exp_reg).car) is (symbol_choose_aexp) is not False):
+                                                                                                        exps = ((exp_reg)).cdr.car
                                                                                                         GLOBALS['k_reg'] = k
                                                                                                         GLOBALS['exps_reg'] = exps
                                                                                                         GLOBALS['pc'] = eval_choices
                                                                                                     else:
-                                                                                                        if (False if ((((exp_reg).car) is (symbol_app_aexp)) is False) else True):
-                                                                                                            info = list_ref(exp_reg, 3)
-                                                                                                            operands = list_ref(exp_reg, 2)
-                                                                                                            operator = list_ref(exp_reg, 1)
+                                                                                                        if (((exp_reg).car) is (symbol_app_aexp) is not False):
+                                                                                                            info = ((((exp_reg)).cdr).cdr).cdr.car
+                                                                                                            operands = (((exp_reg)).cdr).cdr.car
+                                                                                                            operator = ((exp_reg)).cdr.car
                                                                                                             GLOBALS['k_reg'] = make_cont2(b_cont2_64_d, exp_reg, operator, env_reg, info, handler_reg, k)
                                                                                                             GLOBALS['exps_reg'] = operands
                                                                                                             GLOBALS['pc'] = m_star
@@ -8012,7 +8069,7 @@ def m():
                                                                                                             GLOBALS['pc'] = runtime_error
 
 def run_unit_tests():
-    if (False if ((((tests_reg) is symbol_emptylist)) is False) else True):
+    if (((tests_reg) is symbol_emptylist) is not False):
         total = Apply(plus, Map(length, Map(car, dict_to_values(unit_test_table))))
         printf("=================\n")
         printf("Testing completed!\n")
@@ -8033,7 +8090,7 @@ def run_unit_test():
     test_name = (test_reg).car
     nums = (test_reg).cdr
     entry = getitem_native(unit_test_table, test_name)
-    if (False if (((entry) is (False)) is False) else True):
+    if ((entry) is (False) is not False):
         GLOBALS['info_reg'] = symbol_none
         GLOBALS['msg_reg'] = format("test group '~a' not found", test_name)
         GLOBALS['pc'] = runtime_error
@@ -8041,7 +8098,7 @@ def run_unit_test():
         assertions = (entry).car
         env = (entry).cdr.car
         printf("Testing group '~a'...\n", test_name)
-        if (False if ((((nums) is symbol_emptylist)) is False) else True):
+        if (((nums) is symbol_emptylist) is not False):
             GLOBALS['env_reg'] = env
             GLOBALS['verbose_reg'] = False
             GLOBALS['assertions_reg'] = assertions
@@ -8055,20 +8112,20 @@ def run_unit_test():
             GLOBALS['pc'] = filter_assertions
 
 def filter_assertions():
-    if (False if ((((nums_reg) is symbol_emptylist)) is False) else True):
+    if (((nums_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((number_q((nums_reg).car)) is False) else True):
+        if (number_q((nums_reg).car) is not False):
             case_name = format("case ~a", (nums_reg).car)
         else:
             case_name = (nums_reg).car
         return lookup_assertions(test_name_reg, case_name, assertions_reg, symbol_emptylist, handler_reg, fail_reg, make_cont2(b_cont2_87_d, assertions_reg, nums_reg, test_name_reg, handler_reg, k_reg))
 
 def lookup_assertions(test_name, case_name, assertions, accum, handler, fail, k):
-    if (False if ((((assertions) is symbol_emptylist)) is False) else True):
-        if (False if ((((accum) is symbol_emptylist)) is False) else True):
+    if (((assertions) is symbol_emptylist) is not False):
+        if (((accum) is symbol_emptylist) is not False):
             GLOBALS['fail_reg'] = fail
             GLOBALS['handler_reg'] = handler
             GLOBALS['info_reg'] = symbol_none
@@ -8082,9 +8139,9 @@ def lookup_assertions(test_name, case_name, assertions, accum, handler, fail, k)
     else:
         assertion = (assertions).car
         app_aexp_args = (assertion).cdr.cdr.car
-        if (False if ((numeric_equal(length(app_aexp_args), 4)) is False) else True):
+        if (numeric_equal(length(app_aexp_args), 4) is not False):
             lit_aexp_datum = ((app_aexp_args).cdr.cdr.cdr.car).cdr.car
-            if (False if (((string_q(lit_aexp_datum)) and (((string_startswith_q(case_name, "case ")) and (string_is__q(lit_aexp_datum, case_name))) or ((not(string_startswith_q(case_name, "case "))) and (string_startswith_q(lit_aexp_datum, case_name))))) is False) else True):
+            if ((string_q(lit_aexp_datum)) and (((string_startswith_q(case_name, "case ")) and (string_is__q(lit_aexp_datum, case_name))) or ((not(string_startswith_q(case_name, "case "))) and (string_startswith_q(lit_aexp_datum, case_name)))) is not False):
                 return lookup_assertions(test_name, case_name, (assertions).cdr, cons(assertion, accum), handler, fail, k)
             else:
                 return lookup_assertions(test_name, case_name, (assertions).cdr, accum, handler, fail, k)
@@ -8093,7 +8150,7 @@ def valid_exception_type_q(exception_type):
     return (string_q(exception_type)) and ((string_is__q(exception_type, "AssertionError")) or (string_is__q(exception_type, "Exception")) or (string_is__q(exception_type, "KeyboardInterrupt")) or (string_is__q(exception_type, "MacroError")) or (string_is__q(exception_type, "ParseError")) or (string_is__q(exception_type, "ReadError")) or (string_is__q(exception_type, "RunTimeError")) or (string_is__q(exception_type, "ScanError")) or (string_is__q(exception_type, "UnhandledException")))
 
 def run_unit_test_cases():
-    if (False if ((((assertions_reg) is symbol_emptylist)) is False) else True):
+    if (((assertions_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = List(right_reg, wrong_reg)
         GLOBALS['pc'] = apply_cont2
@@ -8106,10 +8163,10 @@ def run_unit_test_cases():
         GLOBALS['pc'] = m
 
 def get_exception_info(exception):
-    column = list_ref(exception, 5)
-    line = list_ref(exception, 4)
-    source = list_ref(exception, 3)
-    if (False if (((source) is (symbol_none)) is False) else True):
+    column = ((((((exception)).cdr).cdr).cdr).cdr).cdr.car
+    line = (((((exception)).cdr).cdr).cdr).cdr.car
+    source = ((((exception)).cdr).cdr).cdr.car
+    if ((source) is (symbol_none) is not False):
         return symbol_none
     else:
         return format("line ~a, column ~a of ~a", line, column, source)
@@ -8118,41 +8175,41 @@ def make_exception(exception_type, message, source, line, column):
     return List(symbol_exception_object, exception_type, message, source, line, column, make_stack_trace())
 
 def get_exception_message(exception):
-    return list_ref(exception, 2)
+    return (((exception)).cdr).cdr.car
 
 def make_stack_trace():
     trace = (_starstack_trace_star).car
     return reverse(Map(format_stack_trace, trace))
 
 def get_procedure_name(aexp):
-    if (False if ((macro_derived_source_info_q(aexp)) is False) else True):
+    if (macro_derived_source_info_q(aexp) is not False):
         return rac(get_source_info(aexp))
     else:
-        if (False if ((((aexp).car) is (symbol_app_aexp)) is False) else True):
-            operator = list_ref(aexp, 1)
-            if (False if ((((operator).car) is (symbol_lexical_address_aexp)) is False) else True):
-                id = list_ref(operator, 3)
+        if (((aexp).car) is (symbol_app_aexp) is not False):
+            operator = ((aexp)).cdr.car
+            if (((operator).car) is (symbol_lexical_address_aexp) is not False):
+                id = ((((operator)).cdr).cdr).cdr.car
                 return id
             else:
-                if (False if ((((operator).car) is (symbol_var_aexp)) is False) else True):
-                    id = list_ref(operator, 1)
+                if (((operator).car) is (symbol_var_aexp) is not False):
+                    id = ((operator)).cdr.car
                     return id
                 else:
-                    if (False if ((((operator).car) is (symbol_lambda_aexp)) is False) else True):
-                        formals = list_ref(operator, 1)
+                    if (((operator).car) is (symbol_lambda_aexp) is not False):
+                        formals = ((operator)).cdr.car
                         return append(List(symbol_lambda), append(List(formals), List(symbol_dotdotdot)))
                     else:
-                        if (False if ((((operator).car) is (symbol_mu_lambda_aexp)) is False) else True):
-                            runt = list_ref(operator, 2)
-                            formals = list_ref(operator, 1)
+                        if (((operator).car) is (symbol_mu_lambda_aexp) is not False):
+                            runt = (((operator)).cdr).cdr.car
+                            formals = ((operator)).cdr.car
                             return append(List(symbol_lambda), append(List(append(formals, runt)), List(symbol_dotdotdot)))
                         else:
-                            if (False if ((((operator).car) is (symbol_trace_lambda_aexp)) is False) else True):
-                                name = list_ref(operator, 1)
+                            if (((operator).car) is (symbol_trace_lambda_aexp) is not False):
+                                name = ((operator)).cdr.car
                                 return name
                             else:
-                                if (False if ((((operator).car) is (symbol_mu_trace_lambda_aexp)) is False) else True):
-                                    name = list_ref(operator, 1)
+                                if (((operator).car) is (symbol_mu_trace_lambda_aexp) is not False):
+                                    name = ((operator)).cdr.car
                                     return name
                                 else:
                                     return symbol_application
@@ -8161,13 +8218,13 @@ def get_procedure_name(aexp):
 
 def format_stack_trace(exp):
     info = rac(exp)
-    if (False if (((info) is (symbol_none)) is False) else True):
+    if ((info) is (symbol_none) is not False):
         return symbol_macro_generated_exp
     else:
         return List(get_srcfile(info), get_start_line(info), get_start_char(info), get_procedure_name(exp))
 
 def runtime_error():
-    if (False if (((info_reg) is (symbol_none)) is False) else True):
+    if ((info_reg) is (symbol_none) is not False):
         GLOBALS['exception_reg'] = make_exception("RunTimeError", msg_reg, symbol_none, symbol_none, symbol_none)
         GLOBALS['pc'] = apply_handler2
     else:
@@ -8178,7 +8235,7 @@ def runtime_error():
         GLOBALS['pc'] = apply_handler2
 
 def assertion_error():
-    if (False if (((info_reg) is (symbol_none)) is False) else True):
+    if ((info_reg) is (symbol_none) is not False):
         GLOBALS['exception_reg'] = make_exception("AssertionError", msg_reg, symbol_none, symbol_none, symbol_none)
         GLOBALS['pc'] = apply_handler2
     else:
@@ -8189,7 +8246,7 @@ def assertion_error():
         GLOBALS['pc'] = apply_handler2
 
 def m_star():
-    if (False if ((((exps_reg) is symbol_emptylist)) is False) else True):
+    if (((exps_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
@@ -8199,7 +8256,7 @@ def m_star():
         GLOBALS['pc'] = m
 
 def eval_sequence():
-    if (False if (((((exps_reg).cdr) is symbol_emptylist)) is False) else True):
+    if ((((exps_reg).cdr) is symbol_emptylist) is not False):
         GLOBALS['exp_reg'] = (exps_reg).car
         GLOBALS['pc'] = m
     else:
@@ -8217,19 +8274,13 @@ def try_catch_finally_handler(cvar, cexps, fexps, env, handler, k):
     return make_handler2(b_handler2_7_d, cexps, cvar, fexps, env, handler, k)
 
 def eval_choices():
-    if (False if ((((exps_reg) is symbol_emptylist)) is False) else True):
+    if (((exps_reg) is symbol_emptylist) is not False):
         GLOBALS['pc'] = apply_fail
     else:
         new_fail = make_fail(b_fail_5_d, exps_reg, env_reg, handler_reg, fail_reg, k_reg)
         GLOBALS['fail_reg'] = new_fail
         GLOBALS['exp_reg'] = (exps_reg).car
         GLOBALS['pc'] = m
-
-def make_empty_docstrings(n):
-    if (False if ((numeric_equal(n, 0)) is False) else True):
-        return symbol_emptylist
-    else:
-        return cons("", make_empty_docstrings((n) - (1)))
 
 def association(var, value):
     return List(var, symbol_colon, value)
@@ -8241,7 +8292,7 @@ def mu_closure(formals, runt, bodies, env):
     return make_proc(b_proc_2_d, bodies, formals, runt, env)
 
 def make_trace_depth_string(level):
-    if (False if ((numeric_equal(level, 0)) is False) else True):
+    if (numeric_equal(level, 0) is not False):
         return ""
     else:
         return string_append(" |", make_trace_depth_string((level) - (1)))
@@ -8249,9 +8300,6 @@ def make_trace_depth_string(level):
 def trace_closure(name, formals, bodies, env):
     trace_depth = 0
     return make_proc(b_proc_3_d, bodies, name, trace_depth, formals, env)
-
-def continuation_object_q(x):
-    return (pair_q(x)) and (memq((x).car, List(symbol_continuation, symbol_continuation2, symbol_continuation3, symbol_continuation4)))
 
 def mu_trace_closure(name, formals, runt, bodies, env):
     trace_depth = 0
@@ -8267,13 +8315,13 @@ def end_of_session_q(x):
     return (x) is (end_of_session)
 
 def string_join():
-    if (False if ((((items_reg) is symbol_emptylist)) is False) else True):
+    if (((items_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = ""
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if (((((items_reg).cdr) is symbol_emptylist)) is False) else True):
+        if ((((items_reg).cdr) is symbol_emptylist) is not False):
             GLOBALS['value2_reg'] = fail_reg
             GLOBALS['value1_reg'] = format("~a", (items_reg).car)
             GLOBALS['k_reg'] = k2_reg
@@ -8301,17 +8349,17 @@ def ends_with_newline_q(s):
     return (GreaterThan(len, 0)) and (equal_q(substring(s, (len) - (1), len), "\n"))
 
 def load_file():
-    if (False if ((member(filename_reg, load_stack)) is False) else True):
+    if (member(filename_reg, load_stack) is not False):
         printf("skipping recursive load of ~a~%", filename_reg)
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = void_value
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((not(string_q(filename_reg))) is False) else True):
+        if (not(string_q(filename_reg)) is not False):
             GLOBALS['msg_reg'] = format("filename '~a' is not a string", filename_reg)
             GLOBALS['pc'] = runtime_error
         else:
-            if (False if ((not(file_exists_q(filename_reg))) is False) else True):
+            if (not(file_exists_q(filename_reg)) is not False):
                 GLOBALS['msg_reg'] = format("attempted to load nonexistent file '~a'", filename_reg)
                 GLOBALS['pc'] = runtime_error
             else:
@@ -8322,7 +8370,7 @@ def load_file():
                 GLOBALS['pc'] = scan_input
 
 def read_and_eval_asexps():
-    if (False if ((token_type_q(first(tokens_reg), symbol_end_marker)) is False) else True):
+    if (token_type_q(first(tokens_reg), symbol_end_marker) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = void_value
         GLOBALS['pc'] = apply_cont2
@@ -8331,7 +8379,7 @@ def read_and_eval_asexps():
         GLOBALS['pc'] = read_sexp
 
 def load_files():
-    if (False if ((((filenames_reg) is symbol_emptylist)) is False) else True):
+    if (((filenames_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = void_value
         GLOBALS['pc'] = apply_cont2
@@ -8342,15 +8390,15 @@ def load_files():
         GLOBALS['pc'] = find_file_and_load
 
 def find_file_and_load():
-    if (False if ((string_startswith_q(filename_reg, "/")) is False) else True):
+    if (string_startswith_q(filename_reg, "/") is not False):
         GLOBALS['pc'] = load_file
     else:
-        if (False if ((((paths_reg) is symbol_emptylist)) is False) else True):
+        if (((paths_reg) is symbol_emptylist) is not False):
             GLOBALS['msg_reg'] = format("attempted to load nonexistent file '~a'", filename_reg)
             GLOBALS['pc'] = runtime_error
         else:
             path = path_join(List((paths_reg).car), filename_reg)
-            if (False if ((file_exists_q(path)) is False) else True):
+            if (file_exists_q(path) is not False):
                 GLOBALS['filename_reg'] = path
                 GLOBALS['pc'] = load_file
             else:
@@ -8358,13 +8406,13 @@ def find_file_and_load():
                 GLOBALS['pc'] = find_file_and_load
 
 def length_loop():
-    if (False if ((((x_reg) is symbol_emptylist)) is False) else True):
+    if (((x_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = sum_reg
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((not(pair_q(x_reg))) is False) else True):
+        if (not(pair_q(x_reg)) is not False):
             GLOBALS['msg_reg'] = format("length called on improper list ~s", ls_reg)
             GLOBALS['pc'] = runtime_error
         else:
@@ -8373,7 +8421,7 @@ def length_loop():
             GLOBALS['pc'] = length_loop
 
 def make_set():
-    if (False if ((((lst_reg) is symbol_emptylist)) is False) else True):
+    if (((lst_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = lst_reg
         GLOBALS['k_reg'] = k2_reg
@@ -8384,23 +8432,23 @@ def make_set():
         GLOBALS['pc'] = make_set
 
 def equal_objects_q():
-    if (False if ((((((x_reg) is symbol_emptylist)) and (((y_reg) is symbol_emptylist))) or ((boolean_q(x_reg)) and (boolean_q(y_reg)) and (((x_reg) and (y_reg)) or ((not(x_reg)) and (not(y_reg))))) or ((symbol_q(x_reg)) and (symbol_q(y_reg)) and ((x_reg) is (y_reg))) or ((number_q(x_reg)) and (number_q(y_reg)) and (numeric_equal(x_reg, y_reg))) or ((char_q(x_reg)) and (char_q(y_reg)) and (char_is__q(x_reg, y_reg))) or (((x_reg) is (void_value)) and ((y_reg) is (void_value))) or ((string_q(x_reg)) and (string_q(y_reg)) and (string_is__q(x_reg, y_reg)))) is False) else True):
+    if (((((x_reg) is symbol_emptylist)) and (((y_reg) is symbol_emptylist))) or ((boolean_q(x_reg)) and (boolean_q(y_reg)) and (((x_reg) and (y_reg)) or ((not(x_reg)) and (not(y_reg))))) or ((symbol_q(x_reg)) and (symbol_q(y_reg)) and ((x_reg) is (y_reg))) or ((number_q(x_reg)) and (number_q(y_reg)) and (numeric_equal(x_reg, y_reg))) or ((char_q(x_reg)) and (char_q(y_reg)) and (char_is__q(x_reg, y_reg))) or (((x_reg) is (void_value)) and ((y_reg) is (void_value))) or ((string_q(x_reg)) and (string_q(y_reg)) and (string_is__q(x_reg, y_reg))) is not False):
         GLOBALS['value_reg'] = True
         GLOBALS['pc'] = apply_cont
     else:
-        if (False if (((pair_q(x_reg)) and (pair_q(y_reg))) is False) else True):
+        if ((pair_q(x_reg)) and (pair_q(y_reg)) is not False):
             GLOBALS['k_reg'] = make_cont(b_cont_51_d, x_reg, y_reg, k_reg)
             GLOBALS['y_reg'] = (y_reg).car
             GLOBALS['x_reg'] = (x_reg).car
             GLOBALS['pc'] = equal_objects_q
         else:
-            if (False if (((vector_q(x_reg)) and (vector_q(y_reg)) and (numeric_equal(vector_length(x_reg), vector_length(y_reg)))) is False) else True):
+            if ((vector_q(x_reg)) and (vector_q(y_reg)) and (numeric_equal(vector_length(x_reg), vector_length(y_reg))) is not False):
                 GLOBALS['i_reg'] = (vector_length(x_reg)) - (1)
                 GLOBALS['v2_reg'] = y_reg
                 GLOBALS['v1_reg'] = x_reg
                 GLOBALS['pc'] = equal_vectors_q
             else:
-                if (False if (((box_q(x_reg)) and (box_q(y_reg))) is False) else True):
+                if ((box_q(x_reg)) and (box_q(y_reg)) is not False):
                     GLOBALS['y_reg'] = unbox(y_reg)
                     GLOBALS['x_reg'] = unbox(x_reg)
                     GLOBALS['pc'] = equal_objects_q
@@ -8409,7 +8457,7 @@ def equal_objects_q():
                     GLOBALS['pc'] = apply_cont
 
 def equal_vectors_q():
-    if (False if ((LessThan(i_reg, 0)) is False) else True):
+    if (LessThan(i_reg, 0) is not False):
         GLOBALS['value_reg'] = True
         GLOBALS['pc'] = apply_cont
     else:
@@ -8419,12 +8467,12 @@ def equal_vectors_q():
         GLOBALS['pc'] = equal_objects_q
 
 def member_loop():
-    if (False if ((((y_reg) is symbol_emptylist)) is False) else True):
+    if (((y_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = False
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((not(pair_q(y_reg))) is False) else True):
+        if (not(pair_q(y_reg)) is not False):
             GLOBALS['msg_reg'] = format("member called on improper list ~s", ls_reg)
             GLOBALS['pc'] = runtime_error
         else:
@@ -8433,7 +8481,7 @@ def member_loop():
             GLOBALS['pc'] = equal_objects_q
 
 def append2():
-    if (False if ((((ls1_reg) is symbol_emptylist)) is False) else True):
+    if (((ls1_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = ls2_reg
         GLOBALS['k_reg'] = k2_reg
@@ -8444,19 +8492,19 @@ def append2():
         GLOBALS['pc'] = append2
 
 def append_all():
-    if (False if ((((lists_reg) is symbol_emptylist)) is False) else True):
+    if (((lists_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if (((((lists_reg).cdr) is symbol_emptylist)) is False) else True):
+        if ((((lists_reg).cdr) is symbol_emptylist) is not False):
             GLOBALS['value2_reg'] = fail_reg
             GLOBALS['value1_reg'] = (lists_reg).car
             GLOBALS['k_reg'] = k2_reg
             GLOBALS['pc'] = apply_cont2
         else:
-            if (False if ((not(list_q((lists_reg).car))) is False) else True):
+            if (not(list_q((lists_reg).car)) is not False):
                 GLOBALS['msg_reg'] = format("append called on incorrect list structure ~s", (lists_reg).car)
                 GLOBALS['pc'] = runtime_error
             else:
@@ -8465,16 +8513,16 @@ def append_all():
                 GLOBALS['pc'] = append_all
 
 def get_completions(args, env):
-    if (False if ((((args) is symbol_emptylist)) is False) else True):
+    if (((args) is symbol_emptylist) is not False):
         return append(get_variables_from_frames(frames(env)), get_variables_from_frames(frames(macro_env)))
     else:
-        if (False if ((environment_q((args).car)) is False) else True):
+        if (environment_q((args).car) is not False):
             return append(get_variables_from_frames(frames((args).car)), get_variables_from_frames(frames(macro_env)))
         else:
             return get_external_members((args).car)
 
 def directory(args, env):
-    if (False if (((((args) is symbol_emptylist)) or (environment_q((args).car))) is False) else True):
+    if ((((args) is symbol_emptylist)) or (environment_q((args).car)) is not False):
         return sort(symbolLessThan_q, (get_variables_from_frames(frames(env)) if ((args) is symbol_emptylist) else get_variables_from_frames(frames((args).car))))
     else:
         return get_external_members((args).car)
@@ -8491,26 +8539,26 @@ def symbolLessThan_q(a, b):
     return stringLessThan_q(a_string, b_string)
 
 def flatten(lists):
-    if (False if ((((lists) is symbol_emptylist)) is False) else True):
+    if (((lists) is symbol_emptylist) is not False):
         return symbol_emptylist
     else:
-        if (False if ((list_q((lists).car)) is False) else True):
+        if (list_q((lists).car) is not False):
             return append(flatten((lists).car), flatten((lists).cdr))
         else:
             return cons((lists).car, flatten((lists).cdr))
 
 def map_primitive():
-    if (False if ((iterator_q((args_reg).car)) is False) else True):
+    if (iterator_q((args_reg).car) is not False):
         GLOBALS['generator_reg'] = (args_reg).car
         GLOBALS['pc'] = iterate_collect
     else:
         list_args = listify(args_reg)
         len = length(args_reg)
-        if (False if ((numeric_equal(len, 1)) is False) else True):
+        if (numeric_equal(len, 1) is not False):
             GLOBALS['list1_reg'] = (list_args).car
             GLOBALS['pc'] = map1
         else:
-            if (False if ((numeric_equal(len, 2)) is False) else True):
+            if (numeric_equal(len, 2) is not False):
                 GLOBALS['list2_reg'] = (list_args).cdr.car
                 GLOBALS['list1_reg'] = (list_args).car
                 GLOBALS['pc'] = map2
@@ -8519,19 +8567,19 @@ def map_primitive():
                 GLOBALS['pc'] = mapN
 
 def listify(arg_list):
-    if (False if ((((arg_list) is symbol_emptylist)) is False) else True):
+    if (((arg_list) is symbol_emptylist) is not False):
         return symbol_emptylist
     else:
-        if (False if ((list_q((arg_list).car)) is False) else True):
+        if (list_q((arg_list).car) is not False):
             return cons((arg_list).car, listify((arg_list).cdr))
         else:
-            if (False if ((vector_q((arg_list).car)) is False) else True):
+            if (vector_q((arg_list).car) is not False):
                 return cons(vector_to_list((arg_list).car), listify((arg_list).cdr))
             else:
-                if (False if ((string_q((arg_list).car)) is False) else True):
+                if (string_q((arg_list).car) is not False):
                     return cons(string_to_list((arg_list).car), listify((arg_list).cdr))
                 else:
-                    if (False if ((iter_q((arg_list).car)) is False) else True):
+                    if (iter_q((arg_list).car) is not False):
                         return cons(vector_to_list(list_native((arg_list).car)), listify((arg_list).cdr))
                     else:
                         raise Exception("symbol_Map: " + format("cannot use object type '~a' in map", *[get_type((arg_list).car)]))
@@ -8543,7 +8591,7 @@ def iterate():
 
 def iterate_continue():
     item = next_item(iterator_reg)
-    if (False if ((((item) is symbol_emptylist)) is False) else True):
+    if (((item) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
@@ -8561,7 +8609,7 @@ def iterate_collect():
 
 def iterate_collect_continue():
     item = next_item(iterator_reg)
-    if (False if ((((item) is symbol_emptylist)) is False) else True):
+    if (((item) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
@@ -8573,12 +8621,12 @@ def iterate_collect_continue():
         GLOBALS['pc'] = apply_proc
 
 def map1():
-    if (False if ((((list1_reg) is symbol_emptylist)) is False) else True):
+    if (((list1_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((dlr_proc_q(proc_reg)) is False) else True):
+        if (dlr_proc_q(proc_reg) is not False):
             GLOBALS['k_reg'] = make_cont2(b_cont2_113_d, list1_reg, proc_reg, k_reg)
             GLOBALS['list1_reg'] = (list1_reg).cdr
             GLOBALS['pc'] = map1
@@ -8590,12 +8638,12 @@ def map1():
             GLOBALS['pc'] = apply_proc
 
 def map2():
-    if (False if ((((list1_reg) is symbol_emptylist)) is False) else True):
+    if (((list1_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((dlr_proc_q(proc_reg)) is False) else True):
+        if (dlr_proc_q(proc_reg) is not False):
             GLOBALS['k_reg'] = make_cont2(b_cont2_115_d, list1_reg, list2_reg, proc_reg, k_reg)
             GLOBALS['list2_reg'] = (list2_reg).cdr
             GLOBALS['list1_reg'] = (list1_reg).cdr
@@ -8608,12 +8656,12 @@ def map2():
             GLOBALS['pc'] = apply_proc
 
 def mapN():
-    if (False if (((((lists_reg).car) is symbol_emptylist)) is False) else True):
+    if ((((lists_reg).car) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((dlr_proc_q(proc_reg)) is False) else True):
+        if (dlr_proc_q(proc_reg) is not False):
             GLOBALS['k_reg'] = make_cont2(b_cont2_117_d, lists_reg, proc_reg, k_reg)
             GLOBALS['lists_reg'] = Map(cdr, lists_reg)
             GLOBALS['pc'] = mapN
@@ -8625,17 +8673,17 @@ def mapN():
             GLOBALS['pc'] = apply_proc
 
 def for_each_primitive():
-    if (False if ((iterator_q((lists_reg).car)) is False) else True):
+    if (iterator_q((lists_reg).car) is not False):
         GLOBALS['generator_reg'] = (lists_reg).car
         GLOBALS['pc'] = iterate
     else:
         arg_list = listify(lists_reg)
-        if (False if (((((arg_list).car) is symbol_emptylist)) is False) else True):
+        if ((((arg_list).car) is symbol_emptylist) is not False):
             GLOBALS['value2_reg'] = fail_reg
             GLOBALS['value1_reg'] = void_value
             GLOBALS['pc'] = apply_cont2
         else:
-            if (False if ((dlr_proc_q(proc_reg)) is False) else True):
+            if (dlr_proc_q(proc_reg) is not False):
                 dlr_apply(proc_reg, Map(car, arg_list))
                 GLOBALS['lists_reg'] = Map(cdr, arg_list)
                 GLOBALS['pc'] = for_each_primitive
@@ -8647,7 +8695,7 @@ def for_each_primitive():
                 GLOBALS['pc'] = apply_proc
 
 def make_dict_tuples():
-    if (False if ((((associations_reg) is symbol_emptylist)) is False) else True):
+    if (((associations_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = symbol_emptylist
         GLOBALS['k_reg'] = k2_reg
@@ -8658,19 +8706,19 @@ def make_dict_tuples():
         GLOBALS['pc'] = make_dict_tuples
 
 def to_string(obj):
-    if (False if ((symbol_q(obj)) is False) else True):
+    if (symbol_q(obj) is not False):
         return symbol_to_string(obj)
     else:
         return obj
 
 def apply_native(proc, args):
-    if (False if ((dlr_proc_q(proc)) is False) else True):
+    if (dlr_proc_q(proc) is not False):
         return dlr_apply(proc, args)
     else:
         return Apply(proc, args)
 
 def insert_element():
-    if (False if ((((elements_reg) is symbol_emptylist)) is False) else True):
+    if (((elements_reg) is symbol_emptylist) is not False):
         GLOBALS['value2_reg'] = fail_reg
         GLOBALS['value1_reg'] = List(x_reg)
         GLOBALS['k_reg'] = k2_reg
@@ -8691,18 +8739,9 @@ def reset_toplevel_env():
 def make_external_proc(external_function_object):
     return make_proc(b_proc_182_d, external_function_object)
 
-def process_formals_and_args(params, args, info, handler, fail):
-    return cons(process_formals(params, info, handler, fail), process_args(args, params, info, handler, fail))
-
-def process_formals(params, info, handler, fail):
-    return Map(get_symbol, params)
-
-def process_args(args, params, info, handler, fail):
-    return args
-
 def get_values_for_params(params, associations, used, info, handler, fail):
-    if (False if ((((params) is symbol_emptylist)) is False) else True):
-        if (False if (((not(((associations) is symbol_emptylist))) and (association_q((associations).car)) and (((associations).car.car) is (symbol_multiply))) is False) else True):
+    if (((params) is symbol_emptylist) is not False):
+        if ((not(((associations) is symbol_emptylist))) and (association_q((associations).car)) and (((associations).car.car) is (symbol_multiply)) is not False):
             return List(get_value((associations).car))
         else:
             return symbol_emptylist
@@ -8712,10 +8751,10 @@ def get_values_for_params(params, associations, used, info, handler, fail):
 def get_value_from_associations(param, associations, info, handler, fail):
     symbol = get_symbol(param)
     value = assq(symbol, associations)
-    if (False if ((value) is False) else True):
+    if (value is not False):
         return get_value(value)
     else:
-        if (False if ((association_q(param)) is False) else True):
+        if (association_q(param) is not False):
             return get_value(param)
         else:
             GLOBALS['fail_reg'] = fail
@@ -8725,35 +8764,35 @@ def get_value_from_associations(param, associations, info, handler, fail):
             GLOBALS['pc'] = runtime_error
 
 def get_arg_associations(args, params, must_be_association, info, handler, fail):
-    if (False if ((((args) is symbol_emptylist)) is False) else True):
+    if (((args) is symbol_emptylist) is not False):
         return symbol_emptylist
     else:
-        if (False if ((association_q((args).car)) is False) else True):
+        if (association_q((args).car) is not False):
             return cons((args).car, get_arg_associations((args).cdr, params, True, info, handler, fail))
         else:
-            if (False if ((must_be_association) is False) else True):
+            if (must_be_association is not False):
                 GLOBALS['fail_reg'] = fail
                 GLOBALS['handler_reg'] = handler
                 GLOBALS['info_reg'] = info
                 GLOBALS['msg_reg'] = format("non-keyword arg following keyword arg: ~a", (args).car)
                 GLOBALS['pc'] = runtime_error
             else:
-                if (False if ((((params) is symbol_emptylist)) is False) else True):
+                if (((params) is symbol_emptylist) is not False):
                     return List(association(symbol_multiply, args))
                 else:
                     return cons(association(get_symbol((params).car), (args).car), get_arg_associations((args).cdr, (params).cdr, False, info, handler, fail))
 
 def get_symbol(item):
-    if (False if ((association_q(item)) is False) else True):
+    if (association_q(item) is not False):
         return (item).car
     else:
-        if (False if ((symbol_q(item)) is False) else True):
+        if (symbol_q(item) is not False):
             return item
         else:
             raise Exception("symbol_get_symbol: " + format("invalid symbol ~a", *[item]))
 
 def get_value(item):
-    if (False if ((association_q(item)) is False) else True):
+    if (association_q(item) is not False):
         return (item).cdr.cdr.car
     else:
         return item
@@ -8762,7 +8801,7 @@ def association_q(x):
     return (list_q(x)) and (numeric_equal(length(x), 3)) and (((x).cdr.car) is (symbol_colon))
 
 def make_associations(dict):
-    if (False if ((((dict) is symbol_emptylist)) is False) else True):
+    if (((dict) is symbol_emptylist) is not False):
         return symbol_emptylist
     else:
         value = (dict).car.cdr.cdr.car
@@ -8779,11 +8818,11 @@ def constant_q(x):
     return (not(pattern_variable_q(x))) and (not(pair_q(x)))
 
 def occurs_q():
-    if (False if ((constant_q(pattern_reg)) is False) else True):
+    if (constant_q(pattern_reg) is not False):
         GLOBALS['value_reg'] = False
         GLOBALS['pc'] = apply_cont
     else:
-        if (False if ((pattern_variable_q(pattern_reg)) is False) else True):
+        if (pattern_variable_q(pattern_reg) is not False):
             GLOBALS['value_reg'] = equal_q(var_reg, pattern_reg)
             GLOBALS['pc'] = apply_cont
         else:
@@ -8792,8 +8831,8 @@ def occurs_q():
             GLOBALS['pc'] = occurs_q
 
 def unify_patterns_hat():
-    if (False if ((pattern_variable_q(p1_reg)) is False) else True):
-        if (False if ((pattern_variable_q(p2_reg)) is False) else True):
+    if (pattern_variable_q(p1_reg) is not False):
+        if (pattern_variable_q(p2_reg) is not False):
             GLOBALS['value_reg'] = make_sub(symbol_unit, p1_reg, p2_reg, ap2_reg)
             GLOBALS['pc'] = apply_cont
         else:
@@ -8802,7 +8841,7 @@ def unify_patterns_hat():
             GLOBALS['var_reg'] = p1_reg
             GLOBALS['pc'] = occurs_q
     else:
-        if (False if ((pattern_variable_q(p2_reg)) is False) else True):
+        if (pattern_variable_q(p2_reg) is not False):
             GLOBALS['temp_1'] = p2_reg
             GLOBALS['temp_2'] = p1_reg
             GLOBALS['temp_3'] = ap2_reg
@@ -8813,11 +8852,11 @@ def unify_patterns_hat():
             GLOBALS['ap2_reg'] = temp_4
             GLOBALS['pc'] = unify_patterns_hat
         else:
-            if (False if (((constant_q(p1_reg)) and (constant_q(p2_reg)) and (equal_q(p1_reg, p2_reg))) is False) else True):
+            if ((constant_q(p1_reg)) and (constant_q(p2_reg)) and (equal_q(p1_reg, p2_reg)) is not False):
                 GLOBALS['value_reg'] = make_sub(symbol_empty)
                 GLOBALS['pc'] = apply_cont
             else:
-                if (False if (((pair_q(p1_reg)) and (pair_q(p2_reg))) is False) else True):
+                if ((pair_q(p1_reg)) and (pair_q(p2_reg)) is not False):
                     GLOBALS['apair2_reg'] = ap2_reg
                     GLOBALS['apair1_reg'] = ap1_reg
                     GLOBALS['pair2_reg'] = p2_reg
@@ -8836,18 +8875,18 @@ def unify_pairs_hat():
     GLOBALS['pc'] = unify_patterns_hat
 
 def instantiate_hat():
-    if (False if ((constant_q(pattern_reg)) is False) else True):
+    if (constant_q(pattern_reg) is not False):
         GLOBALS['value2_reg'] = ap_reg
         GLOBALS['value1_reg'] = pattern_reg
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((pattern_variable_q(pattern_reg)) is False) else True):
+        if (pattern_variable_q(pattern_reg) is not False):
             GLOBALS['avar_reg'] = ap_reg
             GLOBALS['var_reg'] = pattern_reg
             GLOBALS['pc'] = apply_sub_hat
         else:
-            if (False if ((pair_q(pattern_reg)) is False) else True):
+            if (pair_q(pattern_reg) is not False):
                 GLOBALS['k2_reg'] = make_cont2(b_cont2_127_d, ap_reg, pattern_reg, s_reg, k2_reg)
                 GLOBALS['ap_reg'] = car_hat(ap_reg)
                 GLOBALS['pattern_reg'] = (pattern_reg).car
@@ -8861,17 +8900,17 @@ def make_sub(*args):
 
 def apply_sub_hat():
     temp_1 = (s_reg).cdr
-    if (False if ((((temp_1).car) is (symbol_empty)) is False) else True):
+    if (((temp_1).car) is (symbol_empty) is not False):
         GLOBALS['value2_reg'] = avar_reg
         GLOBALS['value1_reg'] = var_reg
         GLOBALS['k_reg'] = k2_reg
         GLOBALS['pc'] = apply_cont2
     else:
-        if (False if ((((temp_1).car) is (symbol_unit)) is False) else True):
-            new_apattern = list_ref(temp_1, 3)
-            new_pattern = list_ref(temp_1, 2)
-            new_var = list_ref(temp_1, 1)
-            if (False if ((equal_q(var_reg, new_var)) is False) else True):
+        if (((temp_1).car) is (symbol_unit) is not False):
+            new_apattern = ((((temp_1)).cdr).cdr).cdr.car
+            new_pattern = (((temp_1)).cdr).cdr.car
+            new_var = ((temp_1)).cdr.car
+            if (equal_q(var_reg, new_var) is not False):
                 GLOBALS['value2_reg'] = new_apattern
                 GLOBALS['value1_reg'] = new_pattern
                 GLOBALS['k_reg'] = k2_reg
@@ -8882,9 +8921,9 @@ def apply_sub_hat():
                 GLOBALS['k_reg'] = k2_reg
                 GLOBALS['pc'] = apply_cont2
         else:
-            if (False if ((((temp_1).car) is (symbol_composite)) is False) else True):
-                s2 = list_ref(temp_1, 2)
-                s1 = list_ref(temp_1, 1)
+            if (((temp_1).car) is (symbol_composite) is not False):
+                s2 = (((temp_1)).cdr).cdr.car
+                s1 = ((temp_1)).cdr.car
                 GLOBALS['k2_reg'] = make_cont2(b_cont2_128_d, s2, k2_reg)
                 GLOBALS['s_reg'] = s1
                 GLOBALS['pc'] = apply_sub_hat

--- a/calysto_scheme/scheme.py
+++ b/calysto_scheme/scheme.py
@@ -685,6 +685,13 @@ def _eval_direct(exp, env):
                 if direct is not None:
                     return direct(args)
                 if len(op) == 6 and fn is b_proc_1_d and op[5]:
+                    pid = id(op)
+                    jit_fn = _jit_lookup(op)
+                    if jit_fn is None:
+                        _jit_compile_proc(op)
+                        jit_fn = _jit_lookup(op)
+                    if jit_fn:
+                        return jit_fn(*args)
                     new_env = _extend_direct(op[4], op[3], args)
                     return _eval_sequence_direct(op[2], new_env)
                 raise _TrampolineFallback()
@@ -693,6 +700,236 @@ def _eval_direct(exp, env):
             raise _TrampolineFallback()
         else:
             raise _TrampolineFallback()
+
+## ===== JIT: compile safe Scheme closures to Python functions =====
+
+def _jit_mangle(sym):
+    """Scheme name → valid Python identifier (prefixed _j_ to avoid collisions)."""
+    s = sym.name if isinstance(sym, Symbol) else str(sym)
+    s = (s.replace('->', '_to_').replace('-', '_').replace('?', '_q')
+          .replace('!', '_b').replace('+', '_add').replace('*', '_mul')
+          .replace('/', '_div').replace('<', '_lt').replace('>', '_gt')
+          .replace('=', '_eq'))
+    if s and s[0].isdigit():
+        s = '_' + s
+    return '_j_' + s
+
+_jit_cache = {}   # id(proc_tuple) → (proc, compiled_fn) or (proc, False)
+
+def _jit_lookup(proc):
+    """Return the cached compiled function for proc, or None if not compiled/failed.
+    Validates that the cached id wasn't reused after GC."""
+    entry = _jit_cache.get(id(proc))
+    if entry is None:
+        return None           # not yet attempted
+    cached_proc, result = entry
+    if cached_proc is not proc:
+        del _jit_cache[id(proc)]  # stale — id was reused after GC
+        return None
+    return result if result is not False else None
+
+def _jit_compile_proc(proc):
+    """Try to JIT-compile a safe Scheme closure.
+    Sets _jit_cache[id(proc)] and returns the compiled fn or None."""
+    pid = id(proc)
+    formals, bodies, cenv = proc[3], proc[2], proc[4]
+    params = []
+    cur = formals
+    while isinstance(cur, cons):
+        params.append(cur.car.name)
+        cur = cur.cdr
+    self_ref = [None]   # forward-reference cell for self-recursive calls
+    free = {}           # name → value captured into the exec() namespace
+    try:
+        jc = _JitCompiler(proc, params, cenv, free, self_ref)
+        body_srcs = []
+        cur = bodies
+        while isinstance(cur, cons):
+            body_srcs.append(jc.expr(cur.car))
+            cur = cur.cdr
+        ps = ', '.join(_jit_mangle(p) for p in params)
+        lines = ['def _jit_fn(' + ps + '):']
+        for i, src in enumerate(body_srcs):
+            lines.append(('    return ' if i == len(body_srcs) - 1 else '    ') + src)
+        fn_src = '\n'.join(lines)
+        ns = dict(free)
+        ns['__builtins__'] = __builtins__
+        exec(compile(fn_src, '<scheme-jit>', 'exec'), ns)
+        fn = ns['_jit_fn']
+        self_ref[0] = fn
+        _jit_cache[pid] = (proc, fn)
+        return fn
+    except _TrampolineFallback:
+        _jit_cache[pid] = (proc, False)
+        return None
+    except Exception:
+        _jit_cache[pid] = (proc, False)
+        return None
+
+class _JitCompiler:
+    """Walks Scheme annotated-AST nodes and emits Python source strings."""
+
+    # Arithmetic: n-ary left-associative (matches Scheme semantics)
+    _NARY  = {'+': '+', '-': '-', '*': '*'}
+    # Binary comparisons
+    _CMP   = {'<': '<', '>': '>', '<=': '<=', '>=': '>=', '=': '=='}
+    # Unary — {0} substituted with the single compiled argument string
+    _UNARY = {
+        'not':   '({0} is False)',
+        'zero?': '({0} == 0)',
+        'even?': '({0} % 2 == 0)',
+        'odd?':  '({0} % 2 != 0)',
+        'car':   '({0}).car',
+        'cdr':   '({0}).cdr',
+        'abs':   'abs({0})',
+        'null?': '({0} is _j__empty)',
+        'pair?': 'isinstance({0}, _j__cons)',
+    }
+
+    def __init__(self, self_proc, params, env, free, self_ref):
+        self._self  = self_proc
+        self._pset  = set(_jit_mangle(p) for p in params)
+        self._env   = env
+        self._free  = free
+        self._sref  = self_ref
+
+    def expr(self, exp):
+        if not isinstance(exp, cons):
+            raise _TrampolineFallback()
+        tag = exp.car
+
+        if tag is symbol_lit_aexp:
+            val = exp.cdr.car
+            if isinstance(val, (int, float, bool, str)):
+                return repr(val)
+            raise _TrampolineFallback()
+
+        elif tag is symbol_lexical_address_aexp:
+            # layout: (tag depth offset name info)
+            # depth=0 → local parameter; depth>0 → free var in captured env
+            depth  = exp.cdr.car
+            offset = exp.cdr.cdr.car
+            name   = exp.cdr.cdr.cdr.car
+            m = _jit_mangle(name)
+            if depth == 0:
+                return m   # local parameter — already in function signature
+            # Outer frame: look up actual value and capture into free
+            if m not in self._free:
+                try:
+                    # depth 1 → frames(cenv)[0], depth 2 → frames(cenv)[1], …
+                    frm = list_ref(frames(self._env), depth - 1)
+                    val = binding_value(vector_ref(frame_bindings(frm), offset))
+                except Exception:
+                    raise _TrampolineFallback()
+                self._capture(m, val)
+            return m
+
+        elif tag is symbol_var_aexp:
+            return self._var(exp.cdr.car)
+
+        elif tag is symbol_if_aexp:
+            # layout: (tag test then else info)
+            test = self.expr(exp.cdr.car)
+            then = self.expr(exp.cdr.cdr.car)
+            els  = self.expr(exp.cdr.cdr.cdr.car)
+            return f'({then} if ({test}) is not False else {els})'
+
+        elif tag is symbol_app_aexp:
+            # layout: (tag op args-list info)
+            return self._app(exp.cdr.car, exp.cdr.cdr.car)
+
+        else:
+            raise _TrampolineFallback()
+
+    def _sym_name(self, op_exp):
+        """Extract the Scheme symbol name from a lex-addr or var operator node."""
+        if not isinstance(op_exp, cons):
+            return None
+        if op_exp.car is symbol_lexical_address_aexp:
+            s = op_exp.cdr.cdr.cdr.car
+            return s.name if isinstance(s, Symbol) else None
+        if op_exp.car is symbol_var_aexp:
+            s = op_exp.cdr.car
+            return s.name if isinstance(s, Symbol) else None
+        return None
+
+    def _app(self, op_exp, arg_list):
+        args = []
+        cur = arg_list
+        while isinstance(cur, cons):
+            args.append(self.expr(cur.car))
+            cur = cur.cdr
+        n   = len(args)
+        sym = self._sym_name(op_exp)
+
+        if sym:
+            # n-ary arithmetic (left-assoc)
+            if sym in self._NARY:
+                op = self._NARY[sym]
+                if n == 0:
+                    return '0' if sym == '+' else '1'
+                if n == 1 and sym == '-':
+                    return f'(-{args[0]})'
+                return '(' + f' {op} '.join(args) + ')'
+            # binary comparisons
+            if sym in self._CMP and n == 2:
+                return f'({args[0]} {self._CMP[sym]} {args[1]})'
+            # unary with inline template
+            if sym in self._UNARY and n == 1:
+                if sym == 'null?':
+                    self._free['_j__empty'] = symbol_emptylist
+                elif sym == 'pair?':
+                    self._free['_j__cons'] = cons
+                return self._UNARY[sym].format(args[0])
+
+        # If the operator is a local parameter (depth=0), we can't know at
+        # compile time whether it'll be a Python callable or a Scheme proc
+        # tuple — refuse to JIT this function.
+        if (isinstance(op_exp, cons) and
+                op_exp.car is symbol_lexical_address_aexp and
+                op_exp.cdr.car == 0):
+            raise _TrampolineFallback()
+
+        # General call: compile operator as expression and emit a call
+        op_src = self.expr(op_exp)
+        return f'{op_src}({", ".join(args)})'
+
+    def _var(self, sym):
+        """Handle var-aexp: local param or captured free variable."""
+        m = _jit_mangle(sym)
+        if m in self._pset or m in self._free:
+            return m
+        b = search_env(self._env, sym)
+        if b is False:
+            raise _TrampolineFallback()
+        self._capture(m, binding_value(b))
+        return m
+
+    def _capture(self, m, val):
+        """Add a free-variable value to self._free, or raise _TrampolineFallback."""
+        if val is self._self:
+            # Self-recursive: wrap the forward-ref cell as a callable
+            sref = self._sref
+            self._free[m] = lambda *a, _r=sref: _r[0](*a)
+            return
+        if isinstance(val, tuple) and val[0] is symbol_procedure:
+            pid = id(val)
+            jit_fn = _jit_lookup(val)
+            if jit_fn is not None:
+                self._free[m] = jit_fn
+                return
+            # Wrap a fast_prim_map entry (list interface → positional interface)
+            if _fast_prim_map is not None:
+                direct = _fast_prim_map.get(val[1])
+                if direct is not None:
+                    self._free[m] = lambda *a, _d=direct: _d(list(a))
+                    return
+            raise _TrampolineFallback()
+        # Plain value (number, string, bool…) — capture directly
+        if isinstance(val, (int, float, bool, str)):
+            self._free[m] = val
+            return
+        raise _TrampolineFallback()
 
 ## Fast prim map: proc[1] function -> Python callable.
 ## Built lazily on first use from the live toplevel environment.

--- a/calysto_scheme/src/README-PERFORMANCE.md
+++ b/calysto_scheme/src/README-PERFORMANCE.md
@@ -14,11 +14,15 @@ python translate_rm.py source-rm.ss ../scheme.py
 `(define (fib n) (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))`
 `(fib 20)` — 21,891 recursive calls, no memoization.
 
-| State | Time | Calls | vs original |
-|-------|------|-------|-------------|
-| Original | 7.4 s | 43 M | 1× |
-| After Phase 1 (trampoline optimizations) | 1.54 s | 6.4 M | **4.8×** |
-| After Phase 2 (direct eval fast path) | 0.081 s | ~330 K | **91×** |
+| State | Time | vs original |
+|-------|------|-------------|
+| Original | 7,400 ms | 1× |
+| After Phase 1 (trampoline optimizations) | 1,540 ms | **4.8×** |
+| After Phase 2 (direct eval fast path) | 82 ms | **91×** |
+| After Phase 3 (JIT to Python) | 1.6 ms | **~4,500×** |
+| Python native | 0.48 ms | — |
+
+The JIT brings Scheme `fib(20)` to within **3.5× of native Python**.
 
 ---
 
@@ -191,7 +195,7 @@ from the fast path, there are no double-execution side effects.
 
 ### `_eval_direct` — recursive AST interpreter
 
-Handles the five most common AST node types. The `if-aexp` branch uses a
+Handles the most common AST node types. The `if-aexp` branch uses a
 `while True` loop for tail-call optimization instead of recursion:
 
 ```python
@@ -211,51 +215,33 @@ def _eval_direct(exp, env):
         elif tag is symbol_if_aexp:
             test = _eval_direct(exp.cdr.car, env)
             exp = exp.cdr.cdr.car if test is not False else exp.cdr.cdr.cdr.car
-            # loop — no Python stack frame consumed for the branch
+        elif tag is symbol_lambda_aexp:
+            return closure(exp.cdr.car, exp.cdr.cdr.car, env)
+        elif tag is symbol_begin_aexp:
+            return _eval_sequence_direct(exp.cdr, env)
         elif tag is symbol_app_aexp:
-            op = _eval_direct(exp.cdr.car, env)
-            args = []
-            cur = exp.cdr.cdr.car
-            while isinstance(cur, cons):
-                args.append(_eval_direct(cur.car, env))
-                cur = cur.cdr
-            # ... apply (see below, inlined for speed)
-        else:
-            raise _TrampolineFallback()
+            # ... (see apply logic below)
 ```
 
 ---
 
-### `_fast_prim_map` — direct primitive dispatch
+### `_fast_prim_map` — direct primitive dispatch (83 entries)
 
-Common primitives (`+`, `-`, `*`, `/`, `<`, `>`, `<=`, `>=`, `=`,
-`not`, `car`, `cdr`, `cons`, `pair?`, `null?`, `zero?`) are stored in the
-environment as Scheme procedure tuples `(symbol_procedure, b_proc_XX_d)`.
-Going through the register-machine wrapper (`b_proc_XX_d`) would defeat
-the purpose of the fast path.
+Common primitives are stored in the environment as Scheme procedure tuples
+`(symbol_procedure, b_proc_XX_d)`. Going through the register-machine wrapper
+would defeat the purpose of the fast path.
 
-Instead, a dict is built **lazily on first use** by looking up each known
-symbol in the live `toplevel_env` and mapping its `b_proc_XX_d` function
-to the underlying Python callable:
+Instead, a dict is built **lazily on first use** mapping each `b_proc_XX_d`
+function to a Python callable that takes a plain Python list of args:
 
 ```python
-def _build_fast_prim_map():
-    name_to_direct = {
-        '+':  lambda args: plus(*args),
-        '-':  lambda args: minus(*args),
-        '<':  lambda args: LessThan(*args),
-        '=':  lambda args: numeric_equal(*args),
-        'car': lambda args: args[0].car,
-        'cons': lambda args: cons(args[0], args[1]),
-        # ... etc.
-    }
-    for sym_name, direct_fn in name_to_direct.items():
-        b = search_env(toplevel_env, make_symbol(sym_name))
-        if b is not False:
-            proc = binding_value(b)
-            if isinstance(proc, tuple) and proc[0] is symbol_procedure:
-                result[proc[1]] = direct_fn
-    return result
+'+':  lambda args: plus(*args),
+'<':  lambda args: LessThan(*args),
+'car': lambda args: args[0].car,
+'length': lambda args: length(args[0]),
+'map': _direct_map,   # uses _apply_direct internally
+# ... 83 total entries covering arithmetic, predicates,
+#     list/vector/string ops, char ops, HOF (map, for-each)
 ```
 
 The `args` parameter is already a **Python list** from `_eval_direct`'s
@@ -285,41 +271,117 @@ def _extend_direct(env, formals, args_list):
 
 ---
 
-### Fast path dispatch in `apply_proc`
+## Phase 3 — JIT compilation to Python
+
+### Overview
+
+Phase 2 still pays per-call overhead: environment extension, AST dispatch,
+and Python function call frames for each recursive step. Phase 3 eliminates
+this entirely for safe functions by compiling their Scheme AST to a **real
+Python function** using `compile()` + `exec()`.
+
+The compiled function runs at native Python speed with no Scheme interpreter
+overhead.
+
+---
+
+### How it works
+
+The Scheme compiler already annotates the AST with variable names inside
+`lexical-address-aexp` nodes:
+
+```
+(lexical-address-aexp depth offset name info)
+```
+
+`depth=0` means a local parameter; `depth>0` means a free variable from
+an outer frame. The name is stored at `exp.cdr.cdr.cdr.car`. This means
+no name-reconstruction is needed — we read names directly from the AST.
+
+`_jit_compile_proc(proc)` walks the AST and emits Python source strings:
+
+| AST node | Generated Python |
+|----------|-----------------|
+| `lit-aexp(v)` | `repr(v)` |
+| `lexical-address-aexp(0, _, name)` | `_j_name` (local param) |
+| `lexical-address-aexp(d, off, name)` | `_j_name` (captured free var) |
+| `if-aexp(test, then, else)` | `(then if (test) is not False else else)` |
+| `app-aexp(+, [a, b])` | `(a + b)` (inlined) |
+| `app-aexp(f, args)` | `f(args...)` |
+
+For `fib`, the generated source is:
 
 ```python
-def apply_proc():
-    if (isinstance(proc_reg, tuple) and len(proc_reg) == 6
-            and proc_reg[1] is b_proc_1_d and proc_reg[5]):
-        bodies, formals, cenv = proc_reg[2], proc_reg[3], proc_reg[4]
-        _args, _k2, _fail = args_reg, k2_reg, fail_reg
-        try:
-            new_env = _extend_direct(cenv, formals, list(iter(_args)) if ... else ...)
-            result = _eval_sequence_direct(bodies, new_env)
-            GLOBALS['value2_reg'] = _fail
-            GLOBALS['value1_reg'] = result
-            GLOBALS['k_reg'] = _k2
-            GLOBALS['pc'] = apply_cont2
-            return
-        except _TrampolineFallback:
-            GLOBALS['args_reg'] = _args   # restore for trampoline fallback
-            GLOBALS['k2_reg']   = _k2
-            GLOBALS['fail_reg'] = _fail
-    proc_reg[1](*proc_reg[2:])            # trampoline path
+def _jit_fn(_j_n):
+    return (_j_n if ((_j_n < 2)) is not False else
+            (_j_fib((_j_n - 1)) + _j_fib((_j_n - 2))))
 ```
 
 ---
 
-### Call count comparison for `(fib 20)`
+### Inlined operators
 
-| Function | Before (trampoline) | After (direct eval) |
-|----------|--------------------|--------------------|
-| `trampoline` steps | ~6.4 M | ~330 K |
-| `m()` (main evaluator) | 273 K | ~0 (for fib body) |
-| `make_cont2` (alloc) | 558 K | ~0 (for fib body) |
-| `_eval_direct` | — | 252 K |
-| primitive calls via `_fast_prim_map` | — | 88 K |
-| `_extend_direct` / `make_frame` | 43 K | 22 K |
+Arithmetic and comparison operators are emitted as Python operators directly,
+avoiding any function call:
+
+```python
+_NARY  = {'+': '+', '-': '-', '*': '*'}   # n-ary, left-assoc
+_CMP   = {'<': '<', '>': '>', '<=': '<=', '>=': '>=', '=': '=='}
+_UNARY = {
+    'not': '({0} is False)',  'zero?': '({0} == 0)',
+    'even?': '({0} % 2 == 0)', 'odd?': '({0} % 2 != 0)',
+    'car': '({0}).car',  'cdr': '({0}).cdr',
+    'null?': '({0} is _j__empty)',  'pair?': 'isinstance({0}, _j__cons)',
+    'abs': 'abs({0})',
+}
+```
+
+---
+
+### Free variable capture
+
+Free variables (depth > 0) are looked up in the closure's captured
+environment at JIT compile time and stored in the `exec()` namespace:
+
+- **Self-recursive calls**: detected by identity (`val is self._proc`);
+  a forward-reference cell `_self_ref = [None]` is injected and patched
+  after compilation.
+- **Already-JIT-compiled siblings**: their compiled Python function is
+  captured directly.
+- **`_fast_prim_map` primitives**: wrapped as `lambda *a, _d=direct: _d(list(a))`
+  to adapt the list interface to positional args.
+- **Local parameters in operator position**: refused at compile time
+  (`_TrampolineFallback`) — can't know at compile time whether the arg
+  will be a Python callable or a Scheme proc tuple.
+
+---
+
+### JIT cache with GC-safe identity check
+
+The cache maps `id(proc)` to `(proc, compiled_fn)`. On lookup, the stored
+proc reference is checked for identity (`cached_proc is proc`) to detect
+`id()` reuse after garbage collection:
+
+```python
+def _jit_lookup(proc):
+    entry = _jit_cache.get(id(proc))
+    if entry is None:
+        return None
+    cached_proc, result = entry
+    if cached_proc is not proc:
+        del _jit_cache[id(proc)]   # stale entry — id reused after GC
+        return None
+    return result if result is not False else None
+```
+
+---
+
+### Fallback safety
+
+If JIT compilation fails for any reason (`_TrampolineFallback` or any
+exception), `_jit_cache[id(proc)] = (proc, False)` is stored and the
+function silently falls back to Phase 2's `_eval_sequence_direct`. No
+user-visible difference.
 
 ---
 
@@ -331,7 +393,13 @@ For reference, production Scheme systems use similar but deeper techniques:
 - **CHICKEN Scheme**: CPS-compiles to C (same architecture as Calysto Scheme), but uses the C call stack directly ("Cheney on the M.T.A.") — GC is triggered when the C stack fills, copying live frames to the heap and continuing.
 - **Guile**: compiles to a register-based bytecode VM with JIT.
 
-The direct-eval fast path in Calysto Scheme is the Python analogue of what CHICKEN does: use the host language's call stack for ordinary function calls, and only fall back to the explicit continuation machinery when needed.
+The Phase 2 direct-eval fast path is the Python analogue of what CHICKEN does:
+use the host language's call stack for ordinary function calls, and fall back
+to the explicit continuation machinery when needed.
+
+The Phase 3 JIT is analogous to what Guile and modern JavaScript engines do:
+compile hot functions to a lower-level representation (native code / Python
+bytecode) that runs without interpreter overhead.
 
 ---
 
@@ -339,7 +407,8 @@ The direct-eval fast path in Calysto Scheme is the Python analogue of what CHICK
 
 | Idea | Expected gain | Effort |
 |------|--------------|--------|
-| Replace `GLOBALS['x'] = val` with `global x; x = val` in generated code | 1.5–3× | Low |
-| Extend `_fast_prim_map` with more primitives (`map`, `length`, `append`, …) | 10–30% | Low |
-| Handle `lambda_aexp` in `_eval_direct` (HOF-heavy code) | varies | Medium |
-| Run on PyPy | 5–20× additional | Zero code changes |
+| JIT: handle `lambda_aexp` (compile HOF-returning functions) | significant for HOF-heavy code | Medium |
+| JIT: handle `assign_aexp` with `nonlocal` declarations | enables `set!` in JIT | Medium |
+| JIT: tail-call via `while True` loop for self-recursive tail calls | eliminates Python stack frames | Medium |
+| Run on PyPy | 5–20× additional on top of existing gains | Zero code changes |
+| Replace `GLOBALS['x'] = val` with `global x; x = val` in generated code | 1.5–3× for trampoline path | Low |

--- a/calysto_scheme/src/README-PERFORMANCE.md
+++ b/calysto_scheme/src/README-PERFORMANCE.md
@@ -1,0 +1,345 @@
+# Calysto Scheme — Python Performance Optimizations
+
+This document describes the performance optimizations made to the
+Python interpreter (`calysto_scheme/scheme.py`) and their implementation
+details. All changes live in `Scheme.py` and `translate_rm.py`; the
+generated `scheme.py` is rebuilt with:
+
+```
+python translate_rm.py source-rm.ss ../scheme.py
+```
+
+## Benchmark
+
+`(define (fib n) (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))`
+`(fib 20)` — 21,891 recursive calls, no memoization.
+
+| State | Time | Calls | vs original |
+|-------|------|-------|-------------|
+| Original | 7.4 s | 43 M | 1× |
+| After Phase 1 (trampoline optimizations) | 1.54 s | 6.4 M | **4.8×** |
+| After Phase 2 (direct eval fast path) | 0.081 s | ~330 K | **91×** |
+
+---
+
+## Architecture background
+
+The interpreter is a **register machine** compiled to Python from Scheme
+source via a CPS (continuation-passing style) pipeline:
+
+```
+reader-cps.ss + environments-cps.ss + parser-cps.ss
+  + interpreter-cps.ss + unifier-cps.ss
+        ↓ compile-ds.ss
+    source-ds.ss   (direct style)
+        ↓ compile-rm.ss
+    source-rm.ss   (register machine)
+        ↓ translate_rm.py
+    scheme.py      (Python)
+```
+
+Execution uses a **trampoline loop**:
+
+```python
+def trampoline():
+    while pc:
+        pc()          # each step sets pc to the next step
+    return final_reg
+```
+
+Every Scheme operation is a step: it reads from ~170 global registers,
+performs work, writes results back, and sets `pc` to the next step.
+Continuations (closures over the current register state) are heap-allocated
+and chained to represent the call stack.
+
+---
+
+## Phase 1 — Trampoline optimizations
+
+### 1. Tuples for continuations and closures
+
+**File:** `Scheme.py`
+
+**Before:** `make_cont(*args)` returned `List(symbol_continuation, *args)` —
+a linked cons-cell list, constructed by converting Python args to a cons
+chain and back on every dispatch.
+
+**After:** `make_cont(*args)` returns `(symbol_continuation,) + args` — a
+plain Python tuple. Apply dispatch becomes:
+
+```python
+def apply_cont():   k_reg[1](*k_reg[2:])
+def apply_proc():   proc_reg[1](*proc_reg[2:])
+```
+
+Continuations, closures, handlers, and fail stacks all use tuples.
+Eliminates `Apply()` / `list_to_vector` overhead on every trampoline step.
+
+**Speedup:** ~10× faster per dispatch step.
+
+---
+
+### 2. Dict-cached environment frames
+
+**File:** `Scheme.py`
+
+Scheme environments are chains of frames; each frame maps variable names
+to mutable binding cells. Variable lookup previously did a linear walk of
+the cons-list of variable names in each frame — O(N) per frame.
+
+**Before (`search_frame`):** iterate over the cons-list of variable names,
+comparing each to the target, then index into the bindings vector.
+
+**After (`make_frame`):** single-pass construction that builds both the
+bindings vector and a `{Symbol → binding_cell}` dict simultaneously.
+`search_frame` does an O(1) dict lookup:
+
+```python
+def make_frame(variables, values, docstrings):
+    bindings, cache = [], {}
+    while isinstance(vars_cur, cons):
+        b = cons(vals_cur.car, docs_cur.car)
+        bindings.append(b)
+        cache[vars_cur.car] = b
+        vars_cur, vals_cur, docs_cur = vars_cur.cdr, vals_cur.cdr, docs_cur.cdr
+    frame = List(Vector(bindings), variables)
+    frame._search_cache = cache
+    return frame
+```
+
+The dict stores references to the **same mutable binding cells**, so
+`set!` semantics are fully preserved.
+
+**Speedup:** ~50× faster variable lookup for frames with many bindings.
+
+---
+
+### 3. Inline constant `list-ref` in the code generator
+
+**File:** `translate_rm.py`
+
+`(list-ref x 2)` with a literal index is compiled to `x.cdr.cdr.car`
+instead of calling the `list_ref()` Python function:
+
+```python
+elif expr[0] == "list-ref" and len(expr) == 3:
+    pos_expr = expr[2]
+    if isinstance(pos_expr, str) and pos_expr.isdigit():
+        n = int(pos_expr)
+        result = "(%s)" % self.process_app(expr[1])
+        for _ in range(n):
+            result = "(%s).cdr" % result
+        return "%s.car" % result
+```
+
+**Speedup:** ~5.6× faster for constant-index list access in the hot interpreter
+inner loop.
+
+---
+
+### 4. Simplified `true_q`
+
+**File:** `translate_rm.py`
+
+**Before:** `(False if ((%s) is False) else True)`
+
+**After:** `(%s is not False)`
+
+**Speedup:** ~30% faster for every boolean test.
+
+---
+
+## Phase 2 — Direct eval fast path
+
+### Overview
+
+The trampoline exists because Python lacks tail-call optimization.
+Every Scheme function call, even `(< n 2)`, went through ~15–20 trampoline
+steps, each involving multiple global register writes and a heap-allocated
+continuation tuple.
+
+The key insight: `call/cc` is **not used internally** by the interpreter
+itself — it is only a user-facing feature. Therefore, user-defined functions
+that contain no `set!` can be evaluated with a direct recursive Python
+interpreter that uses Python's own call stack, completely bypassing the
+trampoline for the duration of the call.
+
+---
+
+### Safety analysis (`_is_direct_eval_safe`)
+
+At closure-creation time (`closure()`), the body AST is walked to check
+for `assign_aexp` (the AST node for `set!`). Functions with no `set!` are
+tagged `safe = True` as element `[5]` of the procedure tuple:
+
+```python
+def closure(formals, bodies, env):
+    safe = _is_direct_eval_safe(bodies)
+    return make_proc(b_proc_1_d, bodies, formals, env, safe)
+```
+
+Inner lambdas are not recursed into — they receive their own safety tag when
+defined.
+
+If `_TrampolineFallback` is raised at any point during direct evaluation
+(e.g., if a call to `call/cc` or an unhandled proc is encountered), `apply_proc`
+restores the original register state and falls through to the trampoline path,
+which re-executes the function correctly. Because `set!` closures are excluded
+from the fast path, there are no double-execution side effects.
+
+---
+
+### `_eval_direct` — recursive AST interpreter
+
+Handles the five most common AST node types. The `if-aexp` branch uses a
+`while True` loop for tail-call optimization instead of recursion:
+
+```python
+def _eval_direct(exp, env):
+    while True:
+        tag = exp.car
+        if tag is symbol_lit_aexp:
+            return exp.cdr.car
+        elif tag is symbol_lexical_address_aexp:
+            d, off = exp.cdr.car, exp.cdr.cdr.car
+            return binding_value(
+                vector_ref(frame_bindings(list_ref(frames(env), d)), off))
+        elif tag is symbol_var_aexp:
+            b = search_env(env, exp.cdr.car)
+            if b is False: raise _TrampolineFallback()
+            return binding_value(b)
+        elif tag is symbol_if_aexp:
+            test = _eval_direct(exp.cdr.car, env)
+            exp = exp.cdr.cdr.car if test is not False else exp.cdr.cdr.cdr.car
+            # loop — no Python stack frame consumed for the branch
+        elif tag is symbol_app_aexp:
+            op = _eval_direct(exp.cdr.car, env)
+            args = []
+            cur = exp.cdr.cdr.car
+            while isinstance(cur, cons):
+                args.append(_eval_direct(cur.car, env))
+                cur = cur.cdr
+            # ... apply (see below, inlined for speed)
+        else:
+            raise _TrampolineFallback()
+```
+
+---
+
+### `_fast_prim_map` — direct primitive dispatch
+
+Common primitives (`+`, `-`, `*`, `/`, `<`, `>`, `<=`, `>=`, `=`,
+`not`, `car`, `cdr`, `cons`, `pair?`, `null?`, `zero?`) are stored in the
+environment as Scheme procedure tuples `(symbol_procedure, b_proc_XX_d)`.
+Going through the register-machine wrapper (`b_proc_XX_d`) would defeat
+the purpose of the fast path.
+
+Instead, a dict is built **lazily on first use** by looking up each known
+symbol in the live `toplevel_env` and mapping its `b_proc_XX_d` function
+to the underlying Python callable:
+
+```python
+def _build_fast_prim_map():
+    name_to_direct = {
+        '+':  lambda args: plus(*args),
+        '-':  lambda args: minus(*args),
+        '<':  lambda args: LessThan(*args),
+        '=':  lambda args: numeric_equal(*args),
+        'car': lambda args: args[0].car,
+        'cons': lambda args: cons(args[0], args[1]),
+        # ... etc.
+    }
+    for sym_name, direct_fn in name_to_direct.items():
+        b = search_env(toplevel_env, make_symbol(sym_name))
+        if b is not False:
+            proc = binding_value(b)
+            if isinstance(proc, tuple) and proc[0] is symbol_procedure:
+                result[proc[1]] = direct_fn
+    return result
+```
+
+The `args` parameter is already a **Python list** from `_eval_direct`'s
+arg accumulation loop — no cons-list construction needed.
+
+---
+
+### `_extend_direct` — environment extension without cons lists
+
+For user closure calls, the new environment frame is built directly from
+the Python args list, bypassing `List(*args)`, `make_empty_docstrings`,
+and the `extend` + `make_frame` function call chain:
+
+```python
+def _extend_direct(env, formals, args_list):
+    bindings, cache = [], {}
+    vars_cur = formals
+    for val in args_list:
+        b = cons(val, "")
+        bindings.append(b)
+        cache[vars_cur.car] = b
+        vars_cur = vars_cur.cdr
+    frame = cons(Vector(bindings), cons(formals, symbol_emptylist))
+    frame._search_cache = cache
+    return cons(symbol_environment, cons(frame, env.cdr))
+```
+
+---
+
+### Fast path dispatch in `apply_proc`
+
+```python
+def apply_proc():
+    if (isinstance(proc_reg, tuple) and len(proc_reg) == 6
+            and proc_reg[1] is b_proc_1_d and proc_reg[5]):
+        bodies, formals, cenv = proc_reg[2], proc_reg[3], proc_reg[4]
+        _args, _k2, _fail = args_reg, k2_reg, fail_reg
+        try:
+            new_env = _extend_direct(cenv, formals, list(iter(_args)) if ... else ...)
+            result = _eval_sequence_direct(bodies, new_env)
+            GLOBALS['value2_reg'] = _fail
+            GLOBALS['value1_reg'] = result
+            GLOBALS['k_reg'] = _k2
+            GLOBALS['pc'] = apply_cont2
+            return
+        except _TrampolineFallback:
+            GLOBALS['args_reg'] = _args   # restore for trampoline fallback
+            GLOBALS['k2_reg']   = _k2
+            GLOBALS['fail_reg'] = _fail
+    proc_reg[1](*proc_reg[2:])            # trampoline path
+```
+
+---
+
+### Call count comparison for `(fib 20)`
+
+| Function | Before (trampoline) | After (direct eval) |
+|----------|--------------------|--------------------|
+| `trampoline` steps | ~6.4 M | ~330 K |
+| `m()` (main evaluator) | 273 K | ~0 (for fib body) |
+| `make_cont2` (alloc) | 558 K | ~0 (for fib body) |
+| `_eval_direct` | — | 252 K |
+| primitive calls via `_fast_prim_map` | — | 88 K |
+| `_extend_direct` / `make_frame` | 43 K | 22 K |
+
+---
+
+## What real Scheme implementations do
+
+For reference, production Scheme systems use similar but deeper techniques:
+
+- **Chez Scheme / Racket**: compile directly to native machine code; the register machine *is* the CPU; continuations are stack-allocated when escape analysis proves they don't escape.
+- **CHICKEN Scheme**: CPS-compiles to C (same architecture as Calysto Scheme), but uses the C call stack directly ("Cheney on the M.T.A.") — GC is triggered when the C stack fills, copying live frames to the heap and continuing.
+- **Guile**: compiles to a register-based bytecode VM with JIT.
+
+The direct-eval fast path in Calysto Scheme is the Python analogue of what CHICKEN does: use the host language's call stack for ordinary function calls, and only fall back to the explicit continuation machinery when needed.
+
+---
+
+## Potential further improvements
+
+| Idea | Expected gain | Effort |
+|------|--------------|--------|
+| Replace `GLOBALS['x'] = val` with `global x; x = val` in generated code | 1.5–3× | Low |
+| Extend `_fast_prim_map` with more primitives (`map`, `length`, `append`, …) | 10–30% | Low |
+| Handle `lambda_aexp` in `_eval_direct` (HOF-heavy code) | varies | Medium |
+| Run on PyPy | 5–20× additional | Zero code changes |

--- a/calysto_scheme/src/Scheme.py
+++ b/calysto_scheme/src/Scheme.py
@@ -511,31 +511,120 @@ def vector_length(vec):
 ### Native make- functions:
 
 def make_proc(*args):
-    return List(symbol_procedure, *args)
+    return (symbol_procedure,) + args
 
 def make_macro(*args):
-    return List(symbol_macro_transformer, *args)
+    return (symbol_macro_transformer,) + args
 
 def make_cont(*args):
-    return List(symbol_continuation, *args)
+    return (symbol_continuation,) + args
 
 def make_cont2(*args):
-    return List(symbol_continuation2, *args)
+    return (symbol_continuation2,) + args
 
 def make_cont3(*args):
-    return List(symbol_continuation3, *args)
+    return (symbol_continuation3,) + args
 
 def make_cont4(*args):
-    return List(symbol_continuation4, *args)
+    return (symbol_continuation4,) + args
 
 def make_fail(*args):
-    return List(symbol_fail_continuation, *args)
+    return (symbol_fail_continuation,) + args
 
 def make_handler(*args):
-    return List(symbol_handler, *args)
+    return (symbol_handler,) + args
 
 def make_handler2(*args):
-    return List(symbol_handler2, *args)
+    return (symbol_handler2,) + args
+
+### Native apply dispatch functions (tuple-based):
+
+def apply_cont():
+    k_reg[1](*k_reg[2:])
+
+def apply_cont2():
+    k_reg[1](*k_reg[2:])
+
+def apply_cont3():
+    k_reg[1](*k_reg[2:])
+
+def apply_cont4():
+    k_reg[1](*k_reg[2:])
+
+def apply_fail():
+    fail_reg[1](*fail_reg[2:])
+
+def apply_handler():
+    handler_reg[1](*handler_reg[2:])
+
+def apply_handler2():
+    handler_reg[1](*handler_reg[2:])
+
+def apply_proc():
+    proc_reg[1](*proc_reg[2:])
+
+def apply_macro():
+    macro_reg[1](*macro_reg[2:])
+
+### Native frame functions (dict-cached for O(1) variable lookup):
+
+def make_frame(variables, values, docstrings):
+    # Single pass: build bindings list and search cache simultaneously
+    bindings = []
+    cache = {}
+    vars_cur, vals_cur, docs_cur = variables, values, docstrings
+    while isinstance(vars_cur, cons):
+        b = cons(vals_cur.car, docs_cur.car)  # make_binding inlined
+        bindings.append(b)
+        cache[vars_cur.car] = b
+        vars_cur = vars_cur.cdr
+        vals_cur = vals_cur.cdr
+        docs_cur = docs_cur.cdr
+    bindings_vector = Vector(bindings)
+    frame = List(bindings_vector, variables)
+    frame._search_cache = cache
+    return frame
+
+def add_binding(new_var, new_binding, frame):
+    vars = (frame).cdr.car
+    old_bindings = (frame).car  # Vector
+    new_bindings = Vector(list(old_bindings) + [new_binding])
+    new_frame = List(new_bindings, append(vars, List(new_var)))
+    cache = getattr(frame, '_search_cache', None)
+    if cache is not None:
+        new_cache = dict(cache)
+        new_cache[new_var] = new_binding
+        new_frame._search_cache = new_cache
+    return new_frame
+
+def continuation_object_q(x):
+    return (isinstance(x, tuple) and len(x) > 0 and
+            x[0] in (symbol_continuation, symbol_continuation2,
+                     symbol_continuation3, symbol_continuation4))
+
+_empty_docstrings_cache = {}
+def make_empty_docstrings(n):
+    if n not in _empty_docstrings_cache:
+        result = symbol_emptylist
+        for _ in range(n):
+            result = cons("", result)
+        _empty_docstrings_cache[n] = result
+    return _empty_docstrings_cache[n]
+
+def process_args(args, params, info, handler, fail):
+    return args
+
+def process_formals(params, info, handler, fail):
+    # Fast path: if all params are plain Symbols, return unchanged (avoids Map allocation)
+    cur = params
+    while isinstance(cur, cons):
+        if not isinstance(cur.car, Symbol):
+            return Map(get_symbol, params)
+        cur = cur.cdr
+    return params
+
+def process_formals_and_args(params, args, info, handler, fail):
+    return cons(process_formals(params, info, handler, fail), args)
 
 ### Native other functions:
 
@@ -631,7 +720,7 @@ def list_q(item):
     return current is symbol_emptylist
 
 def procedure_q(item):
-    return pair_q(item) and (item.car is symbol_procedure)
+    return isinstance(item, tuple) and len(item) > 0 and item[0] is symbol_procedure
 
 def symbol_q(item):
     return ((isinstance(item, Symbol) or association_q(item))
@@ -1026,6 +1115,9 @@ def make_safe(item):
 
 def search_frame(frame, variable):
     if isinstance(frame, cons):
+        cache = getattr(frame, '_search_cache', None)
+        if cache is not None:
+            return cache.get(variable, False)
         bindings = frame.car
         variables = frame.cdr.car
         i = 0

--- a/calysto_scheme/src/Scheme.py
+++ b/calysto_scheme/src/Scheme.py
@@ -689,23 +689,130 @@ _fast_prim_map = None
 def _build_fast_prim_map():
     """Populate the fast prim map by resolving known symbol names in toplevel_env."""
     result = {}
+
+    def _direct_map(args):
+        f, lst = args[0], args[1]
+        items = []
+        while isinstance(lst, cons):
+            items.append(_apply_direct(f, [lst.car]))
+            lst = lst.cdr
+        out = symbol_emptylist
+        for v in reversed(items):
+            out = cons(v, out)
+        return out
+
+    def _direct_for_each(args):
+        f, lst = args[0], args[1]
+        while isinstance(lst, cons):
+            _apply_direct(f, [lst.car])
+            lst = lst.cdr
+        return void_value
+
+    def _set_car(args):
+        args[0].car = args[1]
+        return void_value
+
+    def _set_cdr(args):
+        args[0].cdr = args[1]
+        return void_value
+
     name_to_direct = {
+        # Arithmetic
         '+':     lambda args: plus(*args),
         '-':     lambda args: minus(*args),
         '*':     lambda args: multiply(*args),
         '/':     lambda args: divide(*args),
+        # Numeric comparisons
         '<':     lambda args: LessThan(*args),
         '>':     lambda args: GreaterThan(*args),
         '<=':    lambda args: LessThanEqual(*args),
         '>=':    lambda args: GreaterThanEqual(*args),
         '=':     lambda args: numeric_equal(*args),
+        # Logic
         'not':   lambda args: (args[0] is False),
-        'zero?': lambda args: (args[0] == 0),
-        'null?': lambda args: (args[0] is symbol_emptylist),
-        'pair?': lambda args: pair_q(args[0]),
-        'car':   lambda args: args[0].car,
-        'cdr':   lambda args: args[0].cdr,
-        'cons':  lambda args: cons(args[0], args[1]),
+        # Numeric predicates / math
+        'zero?':     lambda args: (args[0] == 0),
+        'even?':     lambda args: even_q(args[0]),
+        'odd?':      lambda args: odd_q(args[0]),
+        'abs':       lambda args: abs(args[0]),
+        'min':       lambda args: min(*args),
+        'max':       lambda args: max(*args),
+        'modulo':    lambda args: modulo(args[0], args[1]),
+        'remainder': lambda args: remainder(args[0], args[1]),
+        'quotient':  lambda args: quotient(args[0], args[1]),
+        'expt':      lambda args: expt_native(args[0], args[1]),
+        'sqrt':      lambda args: sqrt(args[0]),
+        'round':     lambda args: round(args[0]),
+        # Type predicates
+        'null?':      lambda args: (args[0] is symbol_emptylist),
+        'pair?':      lambda args: pair_q(args[0]),
+        'number?':    lambda args: number_q(args[0]),
+        'string?':    lambda args: string_q(args[0]),
+        'symbol?':    lambda args: symbol_q(args[0]),
+        'char?':      lambda args: char_q(args[0]),
+        'boolean?':   lambda args: boolean_q(args[0]),
+        'vector?':    lambda args: vector_q(args[0]),
+        'list?':      lambda args: list_q(args[0]),
+        'procedure?': lambda args: procedure_q(args[0]),
+        # Equality
+        'eq?':    lambda args: eq_q(args[0], args[1]),
+        'eqv?':   lambda args: eqv_q(args[0], args[1]),
+        'equal?': lambda args: equal_q(args[0], args[1]),
+        # Pair / list construction and access
+        'car':    lambda args: args[0].car,
+        'cdr':    lambda args: args[0].cdr,
+        'cons':   lambda args: cons(args[0], args[1]),
+        'set-car!': _set_car,
+        'set-cdr!': _set_cdr,
+        'caar':   lambda args: args[0].car.car,
+        'cadr':   lambda args: args[0].cdr.car,
+        'cdar':   lambda args: args[0].car.cdr,
+        'cddr':   lambda args: args[0].cdr.cdr,
+        'cadar':  lambda args: args[0].car.cdr.car,
+        'caddr':  lambda args: args[0].cdr.cdr.car,
+        'cdddr':  lambda args: args[0].cdr.cdr.cdr,
+        'cadddr': lambda args: args[0].cdr.cdr.cdr.car,
+        # List operations
+        'list':      lambda args: List(*args),
+        'length':    lambda args: length(args[0]),
+        'reverse':   lambda args: reverse(args[0]),
+        'append':    lambda args: append(*args),
+        'list-ref':  lambda args: list_ref(args[0], args[1]),
+        # Search
+        'memq':   lambda args: memq(args[0], args[1]),
+        'memv':   lambda args: memv(args[0], args[1]),
+        'member': lambda args: member(args[0], args[1]),
+        'assq':   lambda args: assq(args[0], args[1]),
+        'assv':   lambda args: assv(args[0], args[1]),
+        # Vector operations
+        'make-vector':   lambda args: make_vector(args[0]),
+        'vector-ref':    lambda args: vector_ref(args[0], args[1]),
+        'vector-set!':   lambda args: (vector_set_b(args[0], args[1], args[2]), void_value)[1],
+        'vector-length': lambda args: vector_length(args[0]),
+        'vector->list':  lambda args: vector_to_list(args[0]),
+        'list->vector':  lambda args: list_to_vector(args[0]),
+        # String operations
+        'string-length':  lambda args: string_length(args[0]),
+        'string-ref':     lambda args: string_ref(args[0], args[1]),
+        'string-append':  lambda args: string_append(*args),
+        'substring':      lambda args: substring(args[0], args[1], args[2]),
+        'string->list':   lambda args: string_to_list(args[0]),
+        'list->string':   lambda args: list_to_string(args[0]),
+        'string->number': lambda args: string_to_number(args[0]),
+        'number->string': lambda args: number_to_string(args[0]),
+        'string=?':       lambda args: string_is__q(args[0], args[1]),
+        'string<?':       lambda args: stringLessThan_q(args[0], args[1]),
+        # Symbol / char operations
+        'symbol->string':  lambda args: symbol_to_string(args[0]),
+        'string->symbol':  lambda args: string_to_symbol(args[0]),
+        'char->integer':   lambda args: char_to_integer(args[0]),
+        'integer->char':   lambda args: integer_to_char(args[0]),
+        'char-alphabetic?': lambda args: char_alphabetic_q(args[0]),
+        'char-numeric?':    lambda args: char_numeric_q(args[0]),
+        'char-whitespace?': lambda args: char_whitespace_q(args[0]),
+        # Higher-order (propagate _TrampolineFallback if proc not directly evaluable)
+        'map':      _direct_map,
+        'for-each': _direct_for_each,
     }
     for sym_name, direct_fn in name_to_direct.items():
         b = search_env(toplevel_env, make_symbol(sym_name))

--- a/calysto_scheme/src/Scheme.py
+++ b/calysto_scheme/src/Scheme.py
@@ -33,6 +33,9 @@ sys.ps2 = "...: "
 
 PY3 = sys.version_info[0] == 3
 
+# Increase recursion limit for direct-eval fast path (deep Scheme recursion)
+sys.setrecursionlimit(max(10000, sys.getrecursionlimit()))
+
 __version__ = "1.4.9"
 
 #############################################################
@@ -561,10 +564,202 @@ def apply_handler2():
     handler_reg[1](*handler_reg[2:])
 
 def apply_proc():
+    if (isinstance(proc_reg, tuple) and len(proc_reg) == 6
+            and proc_reg[1] is b_proc_1_d and proc_reg[5]):
+        bodies, formals, cenv = proc_reg[2], proc_reg[3], proc_reg[4]
+        _args = args_reg
+        _k2   = k2_reg
+        _fail = fail_reg
+        try:
+            n = length(formals)
+            if n != length(_args):
+                raise _TrampolineFallback()
+            new_env = extend(cenv, formals, _args, make_empty_docstrings(n))
+            result = _eval_sequence_direct(bodies, new_env)
+            GLOBALS['value2_reg'] = _fail
+            GLOBALS['value1_reg'] = result
+            GLOBALS['k_reg'] = _k2
+            GLOBALS['pc'] = apply_cont2
+            return
+        except _TrampolineFallback:
+            GLOBALS['args_reg'] = _args   # restore for b_proc_1_d trampoline fallback
+            GLOBALS['k2_reg']   = _k2
+            GLOBALS['fail_reg'] = _fail
     proc_reg[1](*proc_reg[2:])
 
 def apply_macro():
     macro_reg[1](*macro_reg[2:])
+
+### Direct eval fast path for user closures:
+
+class _TrampolineFallback(Exception):
+    pass
+
+def _is_direct_eval_safe(bodies):
+    """True iff bodies contain no assign_aexp (set!) at any depth.
+    Stops recursion at inner lambda boundaries (they get their own analysis)."""
+    def _safe(exp):
+        if not isinstance(exp, cons):
+            return True
+        tag = exp.car
+        if tag is symbol_assign_aexp:
+            return False
+        # Inner lambdas are separate closures — don't recurse into them
+        if tag is symbol_lambda_aexp or tag is symbol_mu_lambda_aexp:
+            return True
+        cur = exp.cdr
+        while isinstance(cur, cons):
+            if not _safe(cur.car):
+                return False
+            cur = cur.cdr
+        return True
+    cur = bodies
+    while isinstance(cur, cons):
+        if not _safe(cur.car):
+            return False
+        cur = cur.cdr
+    return True
+
+def _extend_direct(env, formals, args_list):
+    """Extend environment from a Python list of arg values — no cons list construction."""
+    bindings = []
+    cache = {}
+    vars_cur = formals
+    for val in args_list:
+        b = cons(val, "")
+        bindings.append(b)
+        cache[vars_cur.car] = b
+        vars_cur = vars_cur.cdr
+    frame = cons(Vector(bindings), cons(formals, symbol_emptylist))
+    frame._search_cache = cache
+    return cons(symbol_environment, cons(frame, env.cdr))
+
+def _eval_direct(exp, env):
+    """Direct recursive AST interpreter. Raises _TrampolineFallback for unhandled cases."""
+    global _fast_prim_map
+    while True:
+        tag = exp.car
+        if tag is symbol_lit_aexp:
+            return exp.cdr.car
+        elif tag is symbol_lexical_address_aexp:
+            d   = exp.cdr.car
+            off = exp.cdr.cdr.car
+            return binding_value(
+                vector_ref(frame_bindings(list_ref(frames(env), d)), off))
+        elif tag is symbol_var_aexp:
+            b = search_env(env, exp.cdr.car)
+            if b is False:
+                raise _TrampolineFallback()
+            return binding_value(b)
+        elif tag is symbol_if_aexp:
+            test = _eval_direct(exp.cdr.car, env)
+            if test is not False:
+                exp = exp.cdr.cdr.car       # tail: loop with then-branch
+            else:
+                exp = exp.cdr.cdr.cdr.car   # tail: loop with else-branch
+        elif tag is symbol_app_aexp:
+            op   = _eval_direct(exp.cdr.car, env)
+            args = []
+            cur  = exp.cdr.cdr.car
+            while isinstance(cur, cons):
+                args.append(_eval_direct(cur.car, env))
+                cur = cur.cdr
+            # Inline _apply_direct for speed:
+            if isinstance(op, tuple) and op[0] is symbol_procedure:
+                fn = op[1]
+                if _fast_prim_map is None:
+                    _fast_prim_map = _build_fast_prim_map()
+                direct = _fast_prim_map.get(fn)
+                if direct is not None:
+                    return direct(args)
+                if len(op) == 6 and fn is b_proc_1_d and op[5]:
+                    new_env = _extend_direct(op[4], op[3], args)
+                    return _eval_sequence_direct(op[2], new_env)
+                raise _TrampolineFallback()
+            elif dlr_proc_q(op):
+                return dlr_apply(op, List(*args))
+            raise _TrampolineFallback()
+        else:
+            raise _TrampolineFallback()
+
+## Fast prim map: proc[1] function -> Python callable.
+## Built lazily on first use from the live toplevel environment.
+_fast_prim_map = None
+
+def _build_fast_prim_map():
+    """Populate the fast prim map by resolving known symbol names in toplevel_env."""
+    result = {}
+    name_to_direct = {
+        '+':     lambda args: plus(*args),
+        '-':     lambda args: minus(*args),
+        '*':     lambda args: multiply(*args),
+        '/':     lambda args: divide(*args),
+        '<':     lambda args: LessThan(*args),
+        '>':     lambda args: GreaterThan(*args),
+        '<=':    lambda args: LessThanEqual(*args),
+        '>=':    lambda args: GreaterThanEqual(*args),
+        '=':     lambda args: numeric_equal(*args),
+        'not':   lambda args: (args[0] is False),
+        'zero?': lambda args: (args[0] == 0),
+        'null?': lambda args: (args[0] is symbol_emptylist),
+        'pair?': lambda args: pair_q(args[0]),
+        'car':   lambda args: args[0].car,
+        'cdr':   lambda args: args[0].cdr,
+        'cons':  lambda args: cons(args[0], args[1]),
+    }
+    for sym_name, direct_fn in name_to_direct.items():
+        b = search_env(toplevel_env, make_symbol(sym_name))
+        if b is not False:
+            proc = binding_value(b)
+            if isinstance(proc, tuple) and proc[0] is symbol_procedure:
+                result[proc[1]] = direct_fn
+    return result
+
+def _apply_direct(proc, args, env):
+    global _fast_prim_map
+    if dlr_proc_q(proc):
+        return dlr_apply(proc, List(*args))
+    if isinstance(proc, tuple) and proc[0] is symbol_procedure:
+        fn = proc[1]
+        if _fast_prim_map is None:
+            _fast_prim_map = _build_fast_prim_map()
+        direct = _fast_prim_map.get(fn)
+        if direct is not None:
+            return direct(args)      # args is a Python list — no cons needed
+        if len(proc) == 6 and fn is b_proc_1_d and proc[5]:
+            bodies, formals, cenv = proc[2], proc[3], proc[4]
+            new_env = extend(cenv, formals, List(*args), make_empty_docstrings(len(args)))
+            return _eval_sequence_direct(bodies, new_env)
+    raise _TrampolineFallback()
+
+def _eval_sequence_direct(bodies, env):
+    cur = bodies
+    while True:
+        exp = cur.car
+        if cur.cdr is symbol_emptylist:
+            return _eval_direct(exp, env)   # tail expression: TCO via _eval_direct loop
+        _eval_direct(exp, env)              # intermediate expr: eval for side effects
+        cur = cur.cdr
+
+### Native b_proc_1_d and closure (direct-eval-aware):
+
+def b_proc_1_d(bodies, formals, env, _safe=False):
+    # _safe is used by apply_proc fast path, ignored here (trampoline path)
+    formals_and_args = process_formals_and_args(formals, args_reg, info_reg, handler_reg, fail_reg)
+    new_formals = (formals_and_args).car
+    new_args = (formals_and_args).cdr
+    if (numeric_equal(length(new_args), length(new_formals)) is not False):
+        GLOBALS['k_reg'] = k2_reg
+        GLOBALS['env_reg'] = extend(env, new_formals, new_args, make_empty_docstrings(length(new_args)))
+        GLOBALS['exps_reg'] = bodies
+        GLOBALS['pc'] = eval_sequence
+    else:
+        GLOBALS['msg_reg'] = "incorrect number of arguments in application"
+        GLOBALS['pc'] = runtime_error
+
+def closure(formals, bodies, env):
+    safe = _is_direct_eval_safe(bodies)
+    return make_proc(b_proc_1_d, bodies, formals, env, safe)
 
 ### Native frame functions (dict-cached for O(1) variable lookup):
 

--- a/calysto_scheme/src/Scheme.py
+++ b/calysto_scheme/src/Scheme.py
@@ -677,6 +677,13 @@ def _eval_direct(exp, env):
                 if direct is not None:
                     return direct(args)
                 if len(op) == 6 and fn is b_proc_1_d and op[5]:
+                    pid = id(op)
+                    jit_fn = _jit_lookup(op)
+                    if jit_fn is None:
+                        _jit_compile_proc(op)
+                        jit_fn = _jit_lookup(op)
+                    if jit_fn:
+                        return jit_fn(*args)
                     new_env = _extend_direct(op[4], op[3], args)
                     return _eval_sequence_direct(op[2], new_env)
                 raise _TrampolineFallback()
@@ -685,6 +692,236 @@ def _eval_direct(exp, env):
             raise _TrampolineFallback()
         else:
             raise _TrampolineFallback()
+
+## ===== JIT: compile safe Scheme closures to Python functions =====
+
+def _jit_mangle(sym):
+    """Scheme name → valid Python identifier (prefixed _j_ to avoid collisions)."""
+    s = sym.name if isinstance(sym, Symbol) else str(sym)
+    s = (s.replace('->', '_to_').replace('-', '_').replace('?', '_q')
+          .replace('!', '_b').replace('+', '_add').replace('*', '_mul')
+          .replace('/', '_div').replace('<', '_lt').replace('>', '_gt')
+          .replace('=', '_eq'))
+    if s and s[0].isdigit():
+        s = '_' + s
+    return '_j_' + s
+
+_jit_cache = {}   # id(proc_tuple) → (proc, compiled_fn) or (proc, False)
+
+def _jit_lookup(proc):
+    """Return the cached compiled function for proc, or None if not compiled/failed.
+    Validates that the cached id wasn't reused after GC."""
+    entry = _jit_cache.get(id(proc))
+    if entry is None:
+        return None           # not yet attempted
+    cached_proc, result = entry
+    if cached_proc is not proc:
+        del _jit_cache[id(proc)]  # stale — id was reused after GC
+        return None
+    return result if result is not False else None
+
+def _jit_compile_proc(proc):
+    """Try to JIT-compile a safe Scheme closure.
+    Sets _jit_cache[id(proc)] and returns the compiled fn or None."""
+    pid = id(proc)
+    formals, bodies, cenv = proc[3], proc[2], proc[4]
+    params = []
+    cur = formals
+    while isinstance(cur, cons):
+        params.append(cur.car.name)
+        cur = cur.cdr
+    self_ref = [None]   # forward-reference cell for self-recursive calls
+    free = {}           # name → value captured into the exec() namespace
+    try:
+        jc = _JitCompiler(proc, params, cenv, free, self_ref)
+        body_srcs = []
+        cur = bodies
+        while isinstance(cur, cons):
+            body_srcs.append(jc.expr(cur.car))
+            cur = cur.cdr
+        ps = ', '.join(_jit_mangle(p) for p in params)
+        lines = ['def _jit_fn(' + ps + '):']
+        for i, src in enumerate(body_srcs):
+            lines.append(('    return ' if i == len(body_srcs) - 1 else '    ') + src)
+        fn_src = '\n'.join(lines)
+        ns = dict(free)
+        ns['__builtins__'] = __builtins__
+        exec(compile(fn_src, '<scheme-jit>', 'exec'), ns)
+        fn = ns['_jit_fn']
+        self_ref[0] = fn
+        _jit_cache[pid] = (proc, fn)
+        return fn
+    except _TrampolineFallback:
+        _jit_cache[pid] = (proc, False)
+        return None
+    except Exception:
+        _jit_cache[pid] = (proc, False)
+        return None
+
+class _JitCompiler:
+    """Walks Scheme annotated-AST nodes and emits Python source strings."""
+
+    # Arithmetic: n-ary left-associative (matches Scheme semantics)
+    _NARY  = {'+': '+', '-': '-', '*': '*'}
+    # Binary comparisons
+    _CMP   = {'<': '<', '>': '>', '<=': '<=', '>=': '>=', '=': '=='}
+    # Unary — {0} substituted with the single compiled argument string
+    _UNARY = {
+        'not':   '({0} is False)',
+        'zero?': '({0} == 0)',
+        'even?': '({0} % 2 == 0)',
+        'odd?':  '({0} % 2 != 0)',
+        'car':   '({0}).car',
+        'cdr':   '({0}).cdr',
+        'abs':   'abs({0})',
+        'null?': '({0} is _j__empty)',
+        'pair?': 'isinstance({0}, _j__cons)',
+    }
+
+    def __init__(self, self_proc, params, env, free, self_ref):
+        self._self  = self_proc
+        self._pset  = set(_jit_mangle(p) for p in params)
+        self._env   = env
+        self._free  = free
+        self._sref  = self_ref
+
+    def expr(self, exp):
+        if not isinstance(exp, cons):
+            raise _TrampolineFallback()
+        tag = exp.car
+
+        if tag is symbol_lit_aexp:
+            val = exp.cdr.car
+            if isinstance(val, (int, float, bool, str)):
+                return repr(val)
+            raise _TrampolineFallback()
+
+        elif tag is symbol_lexical_address_aexp:
+            # layout: (tag depth offset name info)
+            # depth=0 → local parameter; depth>0 → free var in captured env
+            depth  = exp.cdr.car
+            offset = exp.cdr.cdr.car
+            name   = exp.cdr.cdr.cdr.car
+            m = _jit_mangle(name)
+            if depth == 0:
+                return m   # local parameter — already in function signature
+            # Outer frame: look up actual value and capture into free
+            if m not in self._free:
+                try:
+                    # depth 1 → frames(cenv)[0], depth 2 → frames(cenv)[1], …
+                    frm = list_ref(frames(self._env), depth - 1)
+                    val = binding_value(vector_ref(frame_bindings(frm), offset))
+                except Exception:
+                    raise _TrampolineFallback()
+                self._capture(m, val)
+            return m
+
+        elif tag is symbol_var_aexp:
+            return self._var(exp.cdr.car)
+
+        elif tag is symbol_if_aexp:
+            # layout: (tag test then else info)
+            test = self.expr(exp.cdr.car)
+            then = self.expr(exp.cdr.cdr.car)
+            els  = self.expr(exp.cdr.cdr.cdr.car)
+            return f'({then} if ({test}) is not False else {els})'
+
+        elif tag is symbol_app_aexp:
+            # layout: (tag op args-list info)
+            return self._app(exp.cdr.car, exp.cdr.cdr.car)
+
+        else:
+            raise _TrampolineFallback()
+
+    def _sym_name(self, op_exp):
+        """Extract the Scheme symbol name from a lex-addr or var operator node."""
+        if not isinstance(op_exp, cons):
+            return None
+        if op_exp.car is symbol_lexical_address_aexp:
+            s = op_exp.cdr.cdr.cdr.car
+            return s.name if isinstance(s, Symbol) else None
+        if op_exp.car is symbol_var_aexp:
+            s = op_exp.cdr.car
+            return s.name if isinstance(s, Symbol) else None
+        return None
+
+    def _app(self, op_exp, arg_list):
+        args = []
+        cur = arg_list
+        while isinstance(cur, cons):
+            args.append(self.expr(cur.car))
+            cur = cur.cdr
+        n   = len(args)
+        sym = self._sym_name(op_exp)
+
+        if sym:
+            # n-ary arithmetic (left-assoc)
+            if sym in self._NARY:
+                op = self._NARY[sym]
+                if n == 0:
+                    return '0' if sym == '+' else '1'
+                if n == 1 and sym == '-':
+                    return f'(-{args[0]})'
+                return '(' + f' {op} '.join(args) + ')'
+            # binary comparisons
+            if sym in self._CMP and n == 2:
+                return f'({args[0]} {self._CMP[sym]} {args[1]})'
+            # unary with inline template
+            if sym in self._UNARY and n == 1:
+                if sym == 'null?':
+                    self._free['_j__empty'] = symbol_emptylist
+                elif sym == 'pair?':
+                    self._free['_j__cons'] = cons
+                return self._UNARY[sym].format(args[0])
+
+        # If the operator is a local parameter (depth=0), we can't know at
+        # compile time whether it'll be a Python callable or a Scheme proc
+        # tuple — refuse to JIT this function.
+        if (isinstance(op_exp, cons) and
+                op_exp.car is symbol_lexical_address_aexp and
+                op_exp.cdr.car == 0):
+            raise _TrampolineFallback()
+
+        # General call: compile operator as expression and emit a call
+        op_src = self.expr(op_exp)
+        return f'{op_src}({", ".join(args)})'
+
+    def _var(self, sym):
+        """Handle var-aexp: local param or captured free variable."""
+        m = _jit_mangle(sym)
+        if m in self._pset or m in self._free:
+            return m
+        b = search_env(self._env, sym)
+        if b is False:
+            raise _TrampolineFallback()
+        self._capture(m, binding_value(b))
+        return m
+
+    def _capture(self, m, val):
+        """Add a free-variable value to self._free, or raise _TrampolineFallback."""
+        if val is self._self:
+            # Self-recursive: wrap the forward-ref cell as a callable
+            sref = self._sref
+            self._free[m] = lambda *a, _r=sref: _r[0](*a)
+            return
+        if isinstance(val, tuple) and val[0] is symbol_procedure:
+            pid = id(val)
+            jit_fn = _jit_lookup(val)
+            if jit_fn is not None:
+                self._free[m] = jit_fn
+                return
+            # Wrap a fast_prim_map entry (list interface → positional interface)
+            if _fast_prim_map is not None:
+                direct = _fast_prim_map.get(val[1])
+                if direct is not None:
+                    self._free[m] = lambda *a, _d=direct: _d(list(a))
+                    return
+            raise _TrampolineFallback()
+        # Plain value (number, string, bool…) — capture directly
+        if isinstance(val, (int, float, bool, str)):
+            self._free[m] = val
+            return
+        raise _TrampolineFallback()
 
 ## Fast prim map: proc[1] function -> Python callable.
 ## Built lazily on first use from the live toplevel environment.

--- a/calysto_scheme/src/Scheme.py
+++ b/calysto_scheme/src/Scheme.py
@@ -657,6 +657,10 @@ def _eval_direct(exp, env):
                 exp = exp.cdr.cdr.car       # tail: loop with then-branch
             else:
                 exp = exp.cdr.cdr.cdr.car   # tail: loop with else-branch
+        elif tag is symbol_lambda_aexp:
+            return closure(exp.cdr.car, exp.cdr.cdr.car, env)
+        elif tag is symbol_begin_aexp:
+            return _eval_sequence_direct(exp.cdr, env)
         elif tag is symbol_app_aexp:
             op   = _eval_direct(exp.cdr.car, env)
             args = []

--- a/calysto_scheme/src/translate_rm.py
+++ b/calysto_scheme/src/translate_rm.py
@@ -90,6 +90,8 @@ class Translator(object):
             ## formals processing (native fast-path in Scheme.py):
             "process-formals-and-args", "process-formals", "process-args",
             "sort-native", "sort-elements", "insert-elements",
+            ## direct eval fast path (native in Scheme.py):
+            "<proc-1>", "closure",
         ] + self.overrides()
 
     def overrides(self):

--- a/calysto_scheme/src/translate_rm.py
+++ b/calysto_scheme/src/translate_rm.py
@@ -51,8 +51,7 @@ class Translator(object):
         self.initialize()
 
     def true_q(self, item):
-        return "(False if ((%s) is False) else True)" % (item,),
-        #return "(true_q(%s))" % (item,),
+        return "(%s is not False)" % (item,),
 
     def initialize(self):
         pass
@@ -82,6 +81,14 @@ class Translator(object):
             "init-handler", "init-handler2", "init-fail",
             "make-cont", "make-cont2", "make-cont3", "make-cont4", "make-macro", "make-proc",
             "make-fail", "make-handler", "make-handler2",
+            ## apply dispatch (native tuple-based in Scheme.py):
+            "apply-cont", "apply-cont2", "apply-cont3", "apply-cont4",
+            "apply-proc", "apply-macro", "apply-fail", "apply-handler", "apply-handler2",
+            ## frame functions (native dict-cached in Scheme.py):
+            "make-frame", "add-binding", "continuation-object?",
+            "make-empty-docstrings",
+            ## formals processing (native fast-path in Scheme.py):
+            "process-formals-and-args", "process-formals", "process-args",
             "sort-native", "sort-elements", "insert-elements",
         ] + self.overrides()
 
@@ -377,6 +384,18 @@ class PythonTranslator(Translator):
                     exception_message = "\"%s: \" + format(%s, *[%s])" % (
                         expr[1], expr[2], ", ".join([self.process_app(e) for e in expr[3:]]))
                     return "raise Exception(%s)" % exception_message
+                elif expr[0] == "list-ref" and len(expr) == 3:
+                    # Inline constant-position list-ref as direct .cdr.cdr...car access
+                    pos_expr = expr[2]
+                    if isinstance(pos_expr, str) and pos_expr.isdigit():
+                        n = int(pos_expr)
+                        result = "(%s)" % self.process_app(expr[1])
+                        for _ in range(n):
+                            result = "(%s).cdr" % result
+                        return "%s.car" % result
+                    else:
+                        return "list_ref(%s, %s)" % (self.process_app(expr[1]),
+                                                      self.process_app(pos_expr))
                 else:
                     ## function call:
                     if expr[0] in self.convert_to_expression:


### PR DESCRIPTION
## Summary

### Phase 1 — Trampoline optimizations (~4.8×)

- **Tuples for continuations/closures**: Replace cons-list construction with Python tuples. Apply dispatch becomes `k_reg[1](*k_reg[2:])` — eliminates `Apply()`/`list_to_vector` overhead on every trampoline step
- **Dict-cached environment frames**: `make_frame` builds a `{variable → binding}` dict in a single pass. `search_frame` does an O(1) dict lookup instead of O(N) linear scan
- **Inline constant `list-ref`**: `(list-ref x 2)` compiled to `x.cdr.cdr.car` by translate_rm.py
- **Simplified `true_q`**: `(x is not False)` replaces ternary form

### Phase 2 — Direct eval fast path (~19× additional, ~91× total)

Every Scheme function call previously required ~15–20 trampoline steps. Since `call/cc` is only a user-facing feature, safe user-defined functions (no `set!`) can be evaluated with a direct recursive Python interpreter that bypasses the trampoline entirely.

- **`_is_direct_eval_safe`**: walks body AST at closure-creation time, tags safe closures as `proc[5] = True`
- **`_eval_direct`**: recursive AST interpreter for `lit`, `var`, `lexical-address`, `if`, `lambda`, `begin`, `app` nodes
- **`_fast_prim_map`**: 83-entry dict mapping `b_proc_XX_d` → Python callable covering arithmetic, predicates, list/vector/string ops, `map`, `for-each`
- **`_extend_direct`**: builds env frames directly from Python list, no cons overhead
- **`_TrampolineFallback`**: exception-based safety net — any unhandled case falls back to the trampoline with registers restored

### Phase 3 — JIT compilation to Python (~50× additional, ~4,500× total)

Compiles safe Scheme closures to **real Python functions** at first call using `compile()` + `exec()`. The JIT walks the annotated AST (which stores variable names inside `lexical-address-aexp` nodes) and emits Python source strings.

For `fib`, the generated code is:
```python
def _jit_fn(_j_n):
    return (_j_n if ((_j_n < 2)) is not False else
            (_j_fib((_j_n - 1)) + _j_fib((_j_n - 2))))
```

Key implementation details:
- **Inlined operators**: `+`, `-`, `*`, `<`, `>`, `=` etc. emitted as Python operators; `even?`/`odd?`/`null?`/`car`/`cdr` as inline expressions
- **Free variable capture**: depth > 0 vars looked up in closure's captured env at JIT time; `_fast_prim_map` primitives wrapped for positional args
- **Self-recursive forward ref**: detected by identity check (`val is self._proc`), injected as `_self_ref = [None]` cell patched after `exec()`
- **GC-safe cache**: `_jit_lookup` validates `cached_proc is proc` to detect `id()` reuse after garbage collection
- **Conservative HOF handling**: local-param-in-operator-position raises `_TrampolineFallback` at compile time (can't know if arg will be Python callable or Scheme tuple)

## Benchmark

`(define (fib n) (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))`
`(fib 20)` — 21,891 recursive calls, no memoization:

| State | Time | vs original |
|-------|------|-------------|
| Original | 7,400 ms | 1× |
| After Phase 1 | 1,540 ms | **4.8×** |
| After Phase 2 | 82 ms | **91×** |
| After Phase 3 (JIT) | 1.6 ms | **~4,500×** |
| Python native | 0.48 ms | — |

**Within 3.5× of native Python.** All 246 regression tests pass.

## Notes

- `scheme.py` is a generated file — source changes in `Scheme.py` and `translate_rm.py`, regenerated via `python translate_rm.py source-rm.ss ../scheme.py`
- Full implementation details in `calysto_scheme/src/README-PERFORMANCE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
